### PR TITLE
Fix data race on TrainingLinearLayer's transposed weight, and make test tokenisation deterministic

### DIFF
--- a/SharpMind.Model/Layers/TrainingLinearLayer.cs
+++ b/SharpMind.Model/Layers/TrainingLinearLayer.cs
@@ -9,7 +9,6 @@ namespace SharpMind.Model.Layers;
 public sealed class TrainingLinearLayer : LinearLayer
 {
     private static readonly QuantizationOps _staticOps = QuantizationFactory.Create();
-    private Tensor<float>? _weightBT;
     private QuantDType? _qatTarget;
 
     public TrainingLinearLayer(string name, int inFeatures, int outFeatures, bool bias, Tensor<float>? weight, Tensor<float>? biasTensor)
@@ -60,8 +59,10 @@ public sealed class TrainingLinearLayer : LinearLayer
 private unsafe Tensor<float> MatMulForward(Tensor<float> input, int batchSize, Workspace? workspace = null)
     {
         Tensor<float> output;
-        _weightBT?.Dispose();
-        _weightBT = _weight.Transpose();
+        // Local, not a field: MoE calls Forward on one shared expert layer from
+        // several Parallel.For threads at once, so a per-instance transpose gets
+        // disposed under another thread's matmul.
+        using var weightBT = _weight.Transpose();
         if (workspace != null)
             output = workspace.Rent<float>([batchSize, OutFeatures]);
         else
@@ -69,12 +70,12 @@ private unsafe Tensor<float> MatMulForward(Tensor<float> input, int batchSize, W
         if (_qatTarget is null or QuantDType.F32)
         {
             var fn = _staticOps.QuantizedMatMulOpFor(QuantDType.F32);
-            fn(input.DataPtr, (byte*)_weightBT.DataPtr, output.DataPtr, batchSize, InFeatures, OutFeatures);
+            fn(input.DataPtr, (byte*)weightBT.DataPtr, output.DataPtr, batchSize, InFeatures, OutFeatures);
         }
         else
         {
             var fn = _staticOps.QuantizedMatMulOpFor(_qatTarget.Value);
-            var raw = TensorQuantizer.Quantize(_weightBT.Data, [_weightBT.Shape.Rows, _weightBT.Shape.Cols], _qatTarget.Value);
+            var raw = TensorQuantizer.Quantize(weightBT.Data, [weightBT.Shape.Rows, weightBT.Shape.Cols], _qatTarget.Value);
             fixed (byte* rawPtr = raw)
                 fn(input.DataPtr, rawPtr, output.DataPtr, batchSize, InFeatures, OutFeatures);
         }
@@ -124,18 +125,17 @@ private unsafe Tensor<float> MatMulForward(Tensor<float> input, int batchSize, W
         bool needReshape = input.Rank > 2;
         int batchSize = input.ElementCount / input.Shape[^1];
 var flat = needReshape ? input.Reshape(batchSize, InFeatures) : input;
-        _weightBT?.Dispose();
-        _weightBT = _weight.Transpose();
+        using var weightBT = _weight.Transpose();
         var output = new Tensor<float>(batchSize, OutFeatures);
         if (_qatTarget is null or QuantDType.F32)
         {
             var fn = _staticOps.QuantizedMatMulOpFor(QuantDType.F32);
-            fn(flat.DataPtr, (byte*)_weightBT.DataPtr, output.DataPtr, batchSize, InFeatures, OutFeatures);
+            fn(flat.DataPtr, (byte*)weightBT.DataPtr, output.DataPtr, batchSize, InFeatures, OutFeatures);
         }
         else
         {
             var fn = _staticOps.QuantizedMatMulOpFor(_qatTarget.Value);
-            var raw = TensorQuantizer.Quantize(_weightBT.Data, [_weightBT.Shape.Rows, _weightBT.Shape.Cols], _qatTarget.Value);
+            var raw = TensorQuantizer.Quantize(weightBT.Data, [weightBT.Shape.Rows, weightBT.Shape.Cols], _qatTarget.Value);
             fixed (byte* rawPtr = raw)
                 fn(flat.DataPtr, rawPtr, output.DataPtr, batchSize, InFeatures, OutFeatures);
         }
@@ -200,11 +200,5 @@ var flat = needReshape ? input.Reshape(batchSize, InFeatures) : input;
             return reshaped;
         }
         return gradInputFlat;
-    }
-
-    protected override void InvalidateCache()
-    {
-        _weightBT?.Dispose();
-        _weightBT = null;
     }
 }

--- a/SharpMind.Tests/Data/DataLoaderIntegrationTests.cs
+++ b/SharpMind.Tests/Data/DataLoaderIntegrationTests.cs
@@ -12,7 +12,7 @@ public sealed class DataLoaderIntegrationTests : IDisposable
     public void Dispose() => _dir.Dispose();
 
     private static int[] Tokenise(string s) =>
-        [.. s.Split(' ', StringSplitOptions.RemoveEmptyEntries).Select(w => Math.Abs(w.GetHashCode()) % 500)];
+        TestTokens.Encode(s, 500);
 
     [Fact]
     public async Task EndToEnd_TextFile_CleanPipeline_PackedBatches()

--- a/SharpMind.Tests/Data/PackingBatcherTests.cs
+++ b/SharpMind.Tests/Data/PackingBatcherTests.cs
@@ -6,7 +6,7 @@ public sealed class PackingBatcherTests
 {
     // Trivial tokeniser: splits on spaces, returns word indices from a fixed vocab
     private static int[] Tokenise(string s) =>
-        [.. s.Split(' ', StringSplitOptions.RemoveEmptyEntries).Select(w => Math.Abs(w.GetHashCode()) % 1000)];
+        TestTokens.Encode(s, 1000);
 
     private static async Task<List<TrainingBatch>> CollectBatches(
         IEnumerable<string> docs, PackingBatcher batcher)

--- a/SharpMind.Tests/TestHelpers.cs
+++ b/SharpMind.Tests/TestHelpers.cs
@@ -26,6 +26,30 @@ internal sealed class TempDirectory : IDisposable
     }
 }
 
+internal static class TestTokens
+{
+    /// <summary>
+    /// Maps a word to a token id in [0, vocabSize). Uses FNV-1a rather than
+    /// string.GetHashCode(), which is seeded per process — that made every test
+    /// run train on different data, so any assertion on a numeric training
+    /// outcome (e.g. "loss descends") passed or failed at random.
+    /// </summary>
+    public static int Id(string word, int vocabSize)
+    {
+        uint hash = 2166136261u;
+        foreach (char c in word)
+        {
+            hash ^= c;
+            hash *= 16777619u;
+        }
+        return (int)(hash % (uint)vocabSize);
+    }
+
+    /// <summary>Splits on spaces and maps each word with <see cref="Id"/>.</summary>
+    public static int[] Encode(string text, int vocabSize) =>
+        [.. text.Split(' ', StringSplitOptions.RemoveEmptyEntries).Select(w => Id(w, vocabSize))];
+}
+
 internal static class AsyncEnumerableExtensions
 {
     /// <summary>Collects all items from an async enumerable into a list.</summary>

--- a/SharpMind.Tests/Training/CheckpointRetentionTests.cs
+++ b/SharpMind.Tests/Training/CheckpointRetentionTests.cs
@@ -43,9 +43,7 @@ public sealed class CheckpointRetentionTests : IDisposable
         return new DataLoader(pipeline, s => Tokenise(s), new PackingBatcher(batchSize: 2, maxSeqLen: 16));
     }
 
-    private static int[] Tokenise(string s) =>
-        [.. s.Split(' ', System.StringSplitOptions.RemoveEmptyEntries)
-             .Select(w => Math.Abs(w.GetHashCode()) % 16)];
+    private static int[] Tokenise(string s) => TestTokens.Encode(s, 16);
 
     [Fact]
     public async Task KeepRecent2_LeavesTwoRollingPlusFinal()

--- a/SharpMind.Tests/Training/QuantAwareTrainingTests.cs
+++ b/SharpMind.Tests/Training/QuantAwareTrainingTests.cs
@@ -255,8 +255,7 @@ public sealed class QuantAwareTrainingTests : IDisposable
             .Pipe(new NormaliseWhitespace());
         var loader = new DataLoader(
             pipeline,
-            s => s.Split(' ', StringSplitOptions.RemoveEmptyEntries)
-                  .Select(w => Math.Abs(w.GetHashCode()) % QatModelConfig.VocabSize).ToArray(),
+            s => TestTokens.Encode(s, QatModelConfig.VocabSize),
             new PackingBatcher(batchSize: 2, maxSeqLen: 8),
             prefetchBuffer: 1);
 

--- a/SharpMind.Tests/Training/TrainLoopEpochTests.cs
+++ b/SharpMind.Tests/Training/TrainLoopEpochTests.cs
@@ -67,7 +67,5 @@ public sealed class TrainLoopEpochTests : IDisposable
         Assert.Equal(20, lastStep);
     }
 
-    private static int[] Tokenise(string s) =>
-        [.. s.Split(' ', System.StringSplitOptions.RemoveEmptyEntries)
-             .Select(w => Math.Abs(w.GetHashCode()) % 16)];
+    private static int[] Tokenise(string s) => TestTokens.Encode(s, 16);
 }


### PR DESCRIPTION
Two causes of non-deterministic test results, one a real product bug.

## 1. Data race on `TrainingLinearLayer`'s transposed weight

`FfnKernels.MoE` runs `ProcessToken` over tokens with `Parallel.For`, and every token calls `Forward` on the **same** expert `LinearLayer` instances. `TrainingLinearLayer.MatMulForward` did:

```csharp
_weightBT?.Dispose();
_weightBT = _weight.Transpose();
fn(input.DataPtr, (byte*)_weightBT.DataPtr, output.DataPtr, ...);
```

`_weightBT` is shared instance state, so one thread disposed (and returned to `NativeBufferPool`) the transposed weight another thread was mid-matmul on, and both raced to publish the field. The result was silently wrong logits that differed run to run.

This is what made `SmmExportLoadTests.TrainingExport_MoE_ReloadsWithParity` flaky: run alone it failed 4 times in 5, with the reloaded model's logits varying between runs while the original's stayed fixed. Forcing the MoE token loop serial made it pass 5/5, which pinned it to the parallel path.

`_weightBT` was never a cache — it was disposed and recomputed on every call, and nothing outside the two methods that write it ever read it. Making it a local `using` removes the shared state entirely, so no locking is needed and the buffer is freed at end of call instead of lingering. `InvalidateCache` had nothing left to do; the base is a no-op.

`InferenceLinearLayer` writes no instance state in `Forward`, so the inference path was never affected — training only.

## 2. Test token mapping was randomised per process

Five test files mapped words to token ids with `Math.Abs(w.GetHashCode()) % vocabSize`. String hashing is seeded per process in .NET, so every `dotnet test` invocation produced a different corpus→token mapping. Verified directly — the same seven words hashed to three completely different id sequences in three consecutive processes.

For most of those tests the ids are opaque, but `QuantAwareTrainingTests.TrainLoop_WithQat_LossDescends` asserts a numeric training outcome (`losses[^1] < losses[0]` after 12 steps), so it trained on effectively random data and passed or failed by luck — roughly 2 runs in 6. It also explains why all five theory variants failed in lockstep: they share one process, so one unlucky seed sank all of them.

Replaced with a shared FNV-1a helper in `TestHelpers`.

## Verification

- MoE parity test: 10/10 alone (was 4 failures in 5); full suite 644/644 across 8 consecutive runs, where `master` gave 3 failures in 6.
- QAT theory: 6/6 with all 5 variants.
