### PR TITLE
Fix rotary convention, BPE merge loss and GGUF tensor mis-mapping

### DIFF
--- a/SharpMind.Core/Embeddings/RoPE.cs
+++ b/SharpMind.Core/Embeddings/RoPE.cs
@@ -42,11 +42,20 @@ public sealed class RoPE : PositionalEncoder
     /// <param name="ropeOriginalContextLength">Original context length before scaling (NTK-by-parts).</param>
     /// <param name="lowFreqFactor">NTK-by-parts low frequency factor (llama3).</param>
     /// <param name="highFreqFactor">NTK-by-parts high frequency factor (llama3).</param>
+    /// <summary>
+    /// True = NeoX/"rotate_half" pairing (d, d + ropeDim/2); false = adjacent
+    /// pairing (2i, 2i+1). llama.cpp picks this per architecture: LLaMA-family
+    /// GGUFs are converted with Q/K permuted so adjacent pairing is correct,
+    /// while Qwen/Gemma/Phi/StableLM/GPT-NeoX are not permuted and need NeoX.
+    /// </summary>
+    private readonly bool _neoxStyle;
+
     public RoPE(int headDim, int maxSeqLen, float theta = 10_000f,
         int? ropeDim = null, string? ropeScalingType = null, float? ropeScalingFactor = null,
         int? ropeOriginalContextLength = null, float? lowFreqFactor = null, float? highFreqFactor = null,
-        float[]? precomputedFreqs = null)
+        float[]? precomputedFreqs = null, bool neoxStyle = false)
     {
+        _neoxStyle = neoxStyle;
         if (headDim % 2 != 0)
             throw new ArgumentException($"HeadDim must be even, got {headDim}.");
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxSeqLen);
@@ -174,6 +183,24 @@ public sealed class RoPE : PositionalEncoder
             {
                 int offset = (s * numHead + h) * _headDim;
 
+                if (_neoxStyle)
+                {
+                    // NeoX / HF "rotate_half": pair dimension d with d + ropePairs.
+                    // ponytail: scalar only — correctness first; vectorise like the
+                    // adjacent path below if this shows up in a profile.
+                    for (int d = 0; d < ropePairs; d++)
+                    {
+                        float cosN = _cosCache[cacheBase + d];
+                        float sinN = _sinCache[cacheBase + d];
+                        float a = data[offset + d];
+                        float bHalf = data[offset + d + ropePairs];
+
+                        data[offset + d] = a * cosN - bHalf * sinN;
+                        data[offset + d + ropePairs] = bHalf * cosN + a * sinN;
+                    }
+                    continue;
+                }
+
                 // Adjacent-pairing (matches llama.cpp / ggml):
                 // pairs are (data[2i], data[2i + 1]) for i = 0..ropePairs-1,
                 // rotated by angle pos * theta^{-2i/_ropeDim}.
@@ -278,6 +305,21 @@ public sealed class RoPE : PositionalEncoder
             for (int h = 0; h < numHead; h++)
             {
                 int offset = (s * numHead + h) * _headDim;
+
+                if (_neoxStyle)
+                {
+                    for (int d = 0; d < ropePairs; d++)
+                    {
+                        float cosN = _cosCache[cacheBase + d];
+                        float sinN = _sinCache[cacheBase + d];
+                        float g0 = data[offset + d];
+                        float g1 = data[offset + d + ropePairs];
+
+                        data[offset + d] = cosN * g0 + sinN * g1;
+                        data[offset + d + ropePairs] = -sinN * g0 + cosN * g1;
+                    }
+                    continue;
+                }
 
                 for (int i = 0; i < ropePairs; i++)
                 {

--- a/SharpMind.Model/Format/GgufLoader.cs
+++ b/SharpMind.Model/Format/GgufLoader.cs
@@ -609,7 +609,17 @@ public sealed class GgufLoader(QuantizationOps qOps, string path, ModelConfig co
             }
         }
 
-        // Dequantize to float
+        // Dequantize to float — but only if something will consume the floats.
+        // In streaming mode the 2D weight tensors are deliberately left null and
+        // the quantized forward reads the raw bytes instead, so dequantizing here
+        // did full work per layer per forward pass and discarded every value.
+        // Each tensor is seeked to explicitly above, so skipping reads nothing
+        // the next tensor depends on.
+        Tensor<float>? blockFloatTarget = target == null && block != null
+            ? weights.ResolveFloatTarget(info.Name)
+            : null;
+        if (target == null && blockFloatTarget == null) return;
+
         float[] buffer = ArrayPool<float>.Shared.Rent(count);
         try
         {
@@ -631,7 +641,7 @@ public sealed class GgufLoader(QuantizationOps qOps, string path, ModelConfig co
             }
             else if (block != null)
             {
-                var floatTarget = weights.ResolveFloatTarget(info.Name);
+                var floatTarget = blockFloatTarget;
                 if (floatTarget != null)
                 {
                     if (info.Shape.Length == 2)

--- a/SharpMind.Model/Format/GgufLoader.cs
+++ b/SharpMind.Model/Format/GgufLoader.cs
@@ -546,8 +546,17 @@ public sealed class GgufLoader(QuantizationOps qOps, string path, ModelConfig co
         if (targetOffset >= stream.Length) return;
         stream.Position = targetOffset;
 
-        int count = 1;
-        foreach (int d in info.Shape) count *= d;
+        // long: a tensor can hold more elements than int can count (gemma-3n's
+        // per-layer embeddings are 2.3e9), and silently wrapping negative here
+        // surfaced far away as ArrayPool.Rent(-1946157056).
+        long longCount = 1;
+        foreach (int d in info.Shape) longCount *= d;
+        if (longCount > int.MaxValue)
+            throw new NotSupportedException(
+                $"Tensor '{info.Name}' has {longCount:N0} elements, more than this loader can " +
+                $"dequantize into a single float buffer (max {int.MaxValue:N0}). " +
+                "Shape: [" + string.Join(",", info.Shape) + "].");
+        int count = (int)longCount;
 
         // Load raw quantized data for block-level tensors
         if (block != null && rawField != null && rawSize > 0 && stream.Position + rawSize <= stream.Length)
@@ -654,8 +663,13 @@ public sealed class GgufLoader(QuantizationOps qOps, string path, ModelConfig co
 
     private void ReadTensorInto(BinaryReader stream, QuantDType dtype, int[] shape, Span<float> destination)
     {
-        int count = 1;
-        foreach (int d in shape) count *= d;
+        long longCount = 1;
+        foreach (int d in shape) longCount *= d;
+        if (longCount > int.MaxValue)
+            throw new NotSupportedException(
+                $"Tensor with shape [{string.Join(",", shape)}] has {longCount:N0} elements, " +
+                $"more than a single float buffer can hold (max {int.MaxValue:N0}).");
+        int count = (int)longCount;
         if (destination.Length < count) throw new ArgumentException($"Destination buffer too small: {destination.Length} < {count}");
         _qOps.ReadFor(dtype, stream, destination, count);
     }

--- a/SharpMind.Model/Layers/Attention/AttentionLayer.cs
+++ b/SharpMind.Model/Layers/Attention/AttentionLayer.cs
@@ -114,7 +114,32 @@ namespace SharpMind.Model.Layers.Attention;
                  ropeOriginalContextLength: config.RopeOriginalContextLength,
                  lowFreqFactor: config.RopeLowFreqFactor,
                  highFreqFactor: config.RopeHighFreqFactor,
-                 precomputedFreqs: config.PrecomputedRopeFreqs),
+                 precomputedFreqs: config.PrecomputedRopeFreqs,
+                 neoxStyle: UsesNeoxRope(config.Architecture)),
+        };
+    }
+
+    /// <summary>
+    /// Which rotary convention a GGUF architecture expects. llama.cpp fixes this
+    /// per architecture rather than storing it in the file: LLaMA-family models
+    /// are converted with their Q/K weights permuted, so adjacent (2i, 2i+1)
+    /// pairing reproduces HF's rotate_half; the architectures below are NOT
+    /// permuted at conversion and need true NeoX (d, d + ropeDim/2) pairing.
+    /// Getting this wrong leaves the model locally fluent but unable to use
+    /// position — it repeats and cannot recall facts from earlier tokens.
+    /// Unknown architectures keep the previous adjacent behaviour.
+    /// </summary>
+    public static bool UsesNeoxRope(string? architecture)
+    {
+        if (string.IsNullOrWhiteSpace(architecture)) return false;
+
+        return architecture.ToLowerInvariant() switch
+        {
+            "qwen" or "qwen2" or "qwen2moe" or "qwen3" or "qwen3moe" => true,
+            "gemma" or "gemma2" or "gemma3" => true,
+            "phi2" or "phi3" => true,
+            "stablelm" or "gptneox" or "starcoder2" or "olmo2" or "nemotron" or "exaone" => true,
+            _ => false,
         };
     }
 

--- a/SharpMind.Model/TransformerWeights.cs
+++ b/SharpMind.Model/TransformerWeights.cs
@@ -87,7 +87,12 @@ public abstract class TransformerWeights : IDisposable
 
     public (Tensor<float>? target, BlockWeights? block, string? rawField) ResolveTarget(string name)
     {
-        if (name.Contains("token_embd", StringComparison.OrdinalIgnoreCase)) return (EmbeddingWeight, null, null);
+        // "per_layer_token_embd" (gemma-3n/gemma-4) also contains "token_embd" but is a
+        // separate per-layer table, not the token embedding — routing it here fed a
+        // [8960, 262144] tensor into EmbeddingWeight.
+        if (name.Contains("token_embd", StringComparison.OrdinalIgnoreCase)
+            && !name.Contains("per_layer", StringComparison.OrdinalIgnoreCase))
+            return (EmbeddingWeight, null, null);
         if (name.Contains("position_embd", StringComparison.OrdinalIgnoreCase)) return (PositionEmbedding, null, null);
         if (name.Contains("output_norm", StringComparison.OrdinalIgnoreCase))
         {

--- a/SharpMind.Tests/Core/RoPEConventionTests.cs
+++ b/SharpMind.Tests/Core/RoPEConventionTests.cs
@@ -1,0 +1,112 @@
+using SharpMind.Core.Embeddings;
+using SharpMind.Core.Tensors;
+using SharpMind.Model.Layers.Attention;
+using Xunit;
+
+namespace SharpMind.Tests.Core;
+
+/// <summary>
+/// RoPE has two incompatible pairing conventions and the right one depends on
+/// the model architecture:
+///
+///   adjacent ("NORM", GPT-J/ggml): rotates (2i, 2i+1)
+///   NeoX     (HF "rotate_half"):   rotates (d, d + ropeDim/2)
+///
+/// llama.cpp fixes this per architecture rather than storing it in the GGUF.
+/// LLaMA-family files are converted with Q/K permuted so adjacent pairing
+/// reproduces rotate_half; Qwen/Gemma/Phi/StableLM are not permuted and need
+/// true NeoX. Applying adjacent pairing to a Qwen2 model leaves it locally
+/// fluent but unable to use position — it repeats and cannot recall facts
+/// ("The capital of France is" -> " a city in the north of the of the of").
+/// </summary>
+public sealed class RoPEConventionTests
+{
+    private const int HeadDim = 4;
+    private const float Theta = 10_000f;
+
+    // freqs[i] = theta^(-2i/headDim)  ->  [1.0, 0.01] for headDim 4
+    private static readonly float Freq0 = 1f;
+    private static readonly float Freq1 = 1f / MathF.Pow(Theta, 2f * 1 / HeadDim);
+
+    /// <summary>[SeqLen=1, NumHeads=1, HeadDim=4] holding 1,2,3,4.</summary>
+    private static Tensor<float> Input() => Tensor<float>.From([1f, 2f, 3f, 4f], 1, 1, HeadDim);
+
+    [Fact]
+    public void Adjacent_RotatesPairs_2i_2iPlus1()
+    {
+        var rope = new RoPE(HeadDim, maxSeqLen: 8, Theta, neoxStyle: false);
+        using var x = Input();
+
+        rope.Apply(x, positionOffset: 1);
+
+        float c0 = MathF.Cos(Freq0), s0 = MathF.Sin(Freq0);
+        float c1 = MathF.Cos(Freq1), s1 = MathF.Sin(Freq1);
+
+        Assert.Equal(1f * c0 - 2f * s0, x.Data[0], precision: 4);
+        Assert.Equal(2f * c0 + 1f * s0, x.Data[1], precision: 4);
+        Assert.Equal(3f * c1 - 4f * s1, x.Data[2], precision: 4);
+        Assert.Equal(4f * c1 + 3f * s1, x.Data[3], precision: 4);
+    }
+
+    [Fact]
+    public void Neox_RotatesPairs_d_dPlusHalf()
+    {
+        var rope = new RoPE(HeadDim, maxSeqLen: 8, Theta, neoxStyle: true);
+        using var x = Input();
+
+        rope.Apply(x, positionOffset: 1);
+
+        float c0 = MathF.Cos(Freq0), s0 = MathF.Sin(Freq0);
+        float c1 = MathF.Cos(Freq1), s1 = MathF.Sin(Freq1);
+
+        // pairs are (0,2) and (1,3)
+        Assert.Equal(1f * c0 - 3f * s0, x.Data[0], precision: 4);
+        Assert.Equal(2f * c1 - 4f * s1, x.Data[1], precision: 4);
+        Assert.Equal(3f * c0 + 1f * s0, x.Data[2], precision: 4);
+        Assert.Equal(4f * c1 + 2f * s1, x.Data[3], precision: 4);
+    }
+
+    [Fact]
+    public void Conventions_Differ_AtNonZeroPositions()
+    {
+        var adjacent = new RoPE(HeadDim, maxSeqLen: 8, Theta, neoxStyle: false);
+        var neox = new RoPE(HeadDim, maxSeqLen: 8, Theta, neoxStyle: true);
+        using var a = Input();
+        using var n = Input();
+
+        adjacent.Apply(a, positionOffset: 1);
+        neox.Apply(n, positionOffset: 1);
+
+        Assert.NotEqual(a.Data[0], n.Data[0], precision: 3);
+    }
+
+    [Fact]
+    public void Position0_IsIdentity_ForBothConventions()
+    {
+        foreach (bool neox in new[] { false, true })
+        {
+            var rope = new RoPE(HeadDim, maxSeqLen: 8, Theta, neoxStyle: neox);
+            using var x = Input();
+
+            rope.Apply(x, positionOffset: 0);
+
+            Assert.Equal(1f, x.Data[0], precision: 5);
+            Assert.Equal(2f, x.Data[1], precision: 5);
+            Assert.Equal(3f, x.Data[2], precision: 5);
+            Assert.Equal(4f, x.Data[3], precision: 5);
+        }
+    }
+
+    [Theory]
+    [InlineData("qwen2", true)]
+    [InlineData("qwen3", true)]
+    [InlineData("gemma2", true)]
+    [InlineData("phi3", true)]
+    [InlineData("stablelm", true)]
+    [InlineData("llama", false)]
+    [InlineData("baichuan", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void ArchitectureSelectsConvention(string? architecture, bool expected)
+        => Assert.Equal(expected, AttentionLayer.UsesNeoxRope(architecture));
+}

--- a/SharpMind.Tests/Tokenization/BpeMergeCompletenessTests.cs
+++ b/SharpMind.Tests/Tokenization/BpeMergeCompletenessTests.cs
@@ -1,0 +1,83 @@
+using SharpMind.Tokenization;
+using SharpMind.Tokenization.Vocab;
+using Xunit;
+
+namespace SharpMind.Tests.Tokenization;
+
+/// <summary>
+/// BPE must apply every merge the vocabulary supports, not only those adjacent
+/// to the last merge point.
+///
+/// The merge loop used to hold a priority queue of *positions* into a list it
+/// mutated with RemoveAt. A merge shifted every later element down one, so a
+/// queued position further right then referred to the wrong pair, failed
+/// revalidation, and was discarded. Only positions idx-1/idx/idx+1 were
+/// re-queued, so a pending merge separated from the merge point by
+/// unmergeable tokens was lost for good.
+///
+/// Against a real Qwen2 vocabulary that shredded 9 of 20 common words
+/// (" helpful" -> "Ġhelp|fu|l", " assistant" -> "Ġass|is|ta|nt") while
+/// decode(encode(x)) still round-tripped, which is why it went unnoticed.
+/// </summary>
+public sealed class BpeMergeCompletenessTests
+{
+    /// <summary>UNK/BOS/EOS, the 256 GPT-2 byte tokens, then the merge results.</summary>
+    private static Tokenizer BuildTokenizer(string[] extraTokens, string[] merges)
+    {
+        var tokens = new List<string> { "[UNK]", "[BOS]", "[EOS]" };
+        for (int b = 0; b < 256; b++) tokens.Add(Vocabulary.ByteTokenString(b));
+        tokens.AddRange(extraTokens);
+        return Tokenizer.FromGguf([.. tokens], merges, tokenTypes: null, bosId: 1, eosId: 2);
+    }
+
+    /// <summary>
+    /// "abzzzef": (a,b) merges at the far left and (e,f) at the far right, with
+    /// three unmergeable tokens between them so no merge is ever adjacent to
+    /// the (e,f) pair. Merging (a,b) shifts (e,f) left by one; the old code
+    /// dropped its stale queue entry and never revisited it, emitting
+    /// "ab|z|z|z|e|f" instead of "ab|z|z|z|ef".
+    /// </summary>
+    [Fact]
+    public void MergeSeparatedFromMergePoint_IsNotDropped()
+    {
+        var tok = BuildTokenizer(["ab", "ef"], ["a b", "e f"]);
+
+        int[] ids = tok.Encode("abzzzef", addBos: false, addEos: false);
+
+        Assert.Equal(["ab", "z", "z", "z", "ef"], ids.Select(tok.IdToToken).ToArray());
+    }
+
+    /// <summary>Same shape, with the distant merge outranking the near one.</summary>
+    [Fact]
+    public void DistantMerge_SurvivesRegardlessOfRankOrder()
+    {
+        var tok = BuildTokenizer(["ab", "ef"], ["e f", "a b"]);
+
+        int[] ids = tok.Encode("abzzzef", addBos: false, addEos: false);
+
+        Assert.Equal(["ab", "z", "z", "z", "ef"], ids.Select(tok.IdToToken).ToArray());
+    }
+
+    /// <summary>A full merge chain still collapses to the single largest token.</summary>
+    [Fact]
+    public void FullMergeChain_CollapsesToOneToken()
+    {
+        var tok = BuildTokenizer(
+            ["ab", "cd", "ef", "gh", "abcd", "efgh", "abcdefgh"],
+            ["g h", "a b", "e f", "c d", "ab cd", "ef gh", "abcd efgh"]);
+
+        int[] ids = tok.Encode("abcdefgh", addBos: false, addEos: false);
+
+        Assert.Single(ids);
+        Assert.Equal("abcdefgh", tok.IdToToken(ids[0]));
+    }
+
+    [Fact]
+    public void Encode_RoundTripsAfterMerging()
+    {
+        var tok = BuildTokenizer(["ab", "ef"], ["a b", "e f"]);
+
+        foreach (string text in new[] { "abzzzef", "ab", "ef", "zzz" })
+            Assert.Equal(text, tok.Decode(tok.Encode(text, addBos: false, addEos: false)));
+    }
+}

--- a/SharpMind.Tokenization/Bpe/BpeEncoder.cs
+++ b/SharpMind.Tokenization/Bpe/BpeEncoder.cs
@@ -304,48 +304,59 @@ public sealed class BpeEncoder
     /// </summary>
     private void ApplyMerges(List<string> tokens)
     {
-        if (tokens.Count <= 1) return;
+        int n = tokens.Count;
+        if (n <= 1) return;
 
-        // Seed: evaluate all initial adjacent pairs.
-        var queue = new PriorityQueue<int, int>(); // (pairIndex, rank)
-        for (int i = 0; i < tokens.Count - 1; i++)
+        // Slot indices stay stable for the whole merge: a List.RemoveAt would
+        // shift every later element down one, so every queued index to the right
+        // of a merge silently pointed at the wrong pair, failed revalidation and
+        // was dropped. Those merges were then never retried — " helpful" came out
+        // as "Ġhelp|fu|l" even though "Ġhelpful" is in the vocab.
+        var parts = new string[n];
+        tokens.CopyTo(parts);
+        var next = new int[n];
+        var prev = new int[n];
+        var alive = new bool[n];
+        for (int i = 0; i < n; i++)
         {
-            if (_mergeIndex.TryGetValue((tokens[i], tokens[i + 1]), out var entry))
-                queue.Enqueue(i, entry.Rank);
+            next[i] = i + 1 < n ? i + 1 : -1;
+            prev[i] = i - 1;
+            alive[i] = true;
         }
 
-        while (queue.TryDequeue(out int idx, out int rank))
+        var queue = new PriorityQueue<int, int>(); // (left slot, rank)
+        for (int i = 0; i + 1 < n; i++)
         {
-            // --- Lazy-deletion guard ---
-            // The pair at `idx` may have been invalidated by a prior merge.
-            // Re-validate by checking that both halves still match.
-            if (idx >= tokens.Count - 1) continue;
-            if (!_mergeIndex.TryGetValue((tokens[idx], tokens[idx + 1]), out var entry)) continue;
-            if (entry.Rank != rank) continue; // stale — a higher-priority merge replaced one of these tokens
-
-            // --- Merge the pair at idx and idx+1 ---
-            tokens[idx] = entry.Merged;
-            tokens.RemoveAt(idx + 1);
-
-            // Re-evaluate the pair to the LEFT of the merged token (idx-1, idx).
-            if (idx > 0)
-                EnqueueSinglePair(queue, tokens, idx - 1);
-
-            // Re-evaluate the pair to the RIGHT of the merged token (idx, idx+1).
-            if (idx < tokens.Count - 1)
-                EnqueueSinglePair(queue, tokens, idx);
-
-            // Re-evaluate the pair that SHIFTED into position idx+1 (was at idx+2 before RemoveAt).
-            if (idx + 1 < tokens.Count - 1)
-                EnqueueSinglePair(queue, tokens, idx + 1);
+            if (_mergeIndex.TryGetValue((parts[i], parts[i + 1]), out var seed))
+                queue.Enqueue(i, seed.Rank);
         }
-    }
 
-    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-    private void EnqueueSinglePair(PriorityQueue<int, int> queue, List<string> tokens, int idx)
-    {
-        if (_mergeIndex.TryGetValue((tokens[idx], tokens[idx + 1]), out var entry))
-            queue.Enqueue(idx, entry.Rank);
+        while (queue.TryDequeue(out int left, out int rank))
+        {
+            if (!alive[left]) continue;
+            int right = next[left];
+            if (right < 0 || !alive[right]) continue;
+            if (!_mergeIndex.TryGetValue((parts[left], parts[right]), out var entry)) continue;
+            if (entry.Rank != rank) continue; // stale: this slot's pair changed since enqueue
+
+            parts[left] = entry.Merged;
+            alive[right] = false;
+
+            int after = next[right];
+            next[left] = after;
+            if (after >= 0) prev[after] = left;
+
+            int before = prev[left];
+            if (before >= 0 && _mergeIndex.TryGetValue((parts[before], parts[left]), out var leftPair))
+                queue.Enqueue(before, leftPair.Rank);
+            if (after >= 0 && _mergeIndex.TryGetValue((parts[left], parts[after]), out var rightPair))
+                queue.Enqueue(left, rightPair.Rank);
+        }
+
+        // Slot 0 is never removed (only the right half of a pair is), so the
+        // surviving chain always starts there.
+        tokens.Clear();
+        for (int i = 0; i >= 0; i = next[i]) tokens.Add(parts[i]);
     }
 
     private void EncodeSentencePieceSegment(string text, bool isFirstSegment, List<int> ids)
@@ -399,30 +410,57 @@ public sealed class BpeEncoder
     {
         if (tokens.Count <= 1) return;
 
+        // Same stable-slot scheme as ApplyMerges: RemoveAt shifted positions out
+        // from under queued indices, dropping merges (and here, with no score
+        // revalidation, a shifted index could merge a pair that was never queued).
+        int n = tokens.Count;
+        var parts = new string[n];
+        for (int i = 0; i < n; i++) parts[i] = tokens[i].ToString();
+        var next = new int[n];
+        var prev = new int[n];
+        var alive = new bool[n];
+        for (int i = 0; i < n; i++)
+        {
+            next[i] = i + 1 < n ? i + 1 : -1;
+            prev[i] = i - 1;
+            alive[i] = true;
+        }
+
         var queue = new PriorityQueue<int, float>();
 
-        void TryEnqueue(int idx)
+        void TryEnqueue(int left)
         {
-            if (idx < 0 || idx >= tokens.Count - 1) return;
-            string merged = tokens[idx].ToString() + tokens[idx + 1].ToString();
-            if (_vocab.TryGetId(merged, out int id))
-                queue.Enqueue(idx, -ScoreOf(id));
+            if (left < 0 || !alive[left]) return;
+            int right = next[left];
+            if (right < 0 || !alive[right]) return;
+            if (_vocab.TryGetId(parts[left] + parts[right], out int id))
+                queue.Enqueue(left, -ScoreOf(id));
         }
 
-        for (int i = 0; i < tokens.Count - 1; i++) TryEnqueue(i);
+        for (int i = 0; i < n; i++) TryEnqueue(i);
 
-        while (queue.TryDequeue(out int idx, out _))
+        while (queue.TryDequeue(out int left, out float priority))
         {
-            if (idx >= tokens.Count - 1) continue;
-            string merged = tokens[idx].ToString() + tokens[idx + 1].ToString();
-            if (!_vocab.TryGetId(merged, out _)) continue;
+            if (!alive[left]) continue;
+            int right = next[left];
+            if (right < 0 || !alive[right]) continue;
+            string merged = parts[left] + parts[right];
+            if (!_vocab.TryGetId(merged, out int id)) continue;
+            if (-ScoreOf(id) != priority) continue; // stale: this slot's pair changed
 
-            tokens[idx] = merged.AsMemory();
-            tokens.RemoveAt(idx + 1);
+            parts[left] = merged;
+            alive[right] = false;
 
-            if (idx > 0) TryEnqueue(idx - 1);
-            if (idx < tokens.Count - 1) TryEnqueue(idx);
+            int after = next[right];
+            next[left] = after;
+            if (after >= 0) prev[after] = left;
+
+            TryEnqueue(prev[left]);
+            TryEnqueue(left);
         }
+
+        tokens.Clear();
+        for (int i = 0; i >= 0; i = next[i]) tokens.Add(parts[i].AsMemory());
     }
 
     private float ScoreOf(int id) => _scores != null && id >= 0 && id < _scores.Count ? _scores[id] : 0f;


### PR DESCRIPTION
Three correctness bugs in the model path. Together they take qwen2-0.5b-instruct from incoherent to correct:

```
before:  "The capital of France is"       -> " a city in the north of the of the of the of"
         "What is the capital of France?" -> "The capital city of France, it's capital and its
                                              historical center, Paris, which is the most famous
                                              for its in the of the of the of the the the of..."

after:   "What is the capital of France?" -> "The capital of France is Paris."
         "What is 2 + 2?"                 -> "The sum of 2 and 2 is 4."
```

## 1. Wrong rotary convention (the big one)

RoPE has two incompatible pairings:

| convention | pairs |
|---|---|
| adjacent ("NORM", GPT-J/ggml) | `(2i, 2i+1)` |
| NeoX (HF `rotate_half`) | `(d, d + ropeDim/2)` |

llama.cpp fixes this **per architecture** rather than recording it in the GGUF. LLaMA-family models are converted with their Q/K weights permuted, so adjacent pairing reproduces `rotate_half`; Qwen, Gemma, Phi, StableLM and GPT-NeoX are **not** permuted at conversion and need true NeoX.

SharpMind implemented only adjacent pairing and applied it to every model. The loop's own comment recorded the reasoning:

```
// (Empirically verified against llama.cpp for Llama-3.2: the
//  half-pairing convention diverges for positions >= 1.)
```

That verification was correct — for Llama-3.2, a NORM-family model — and was then generalised to architectures where it does not hold. The model stayed locally fluent because embeddings and FFN were fine, but it could not use position, so it could not attend back to the relevant tokens and fell into repetition. This also matches the split recorded in the old SandBox (`KnownWorkingModels` vs `KnownGiberishModels`) and why a `RopeConventionRunner` existed.

`RoPE` now takes a `neoxStyle` flag (NeoX path scalar for now; the adjacent path keeps its SSE loop) and `AttentionLayer.UsesNeoxRope` maps architecture → convention. **Unknown architectures keep the previous adjacent behaviour, so nothing that already worked changes.**

Ruled out by measurement before landing on this: quantization (fp16/q8_0/q4_k_m give byte-identical output), the KV cache (cached and uncached greedy produce identical ids), sampling, config (all 10 fields match the Qwen2-0.5B reference including `RopeTheta=1000000`), and qkv-bias allocation.

## 2. BPE silently dropped merges

`ApplyMerges` held a priority queue of *positions* into a `List<string>` it mutated with `RemoveAt`. A merge shifted every later element down one, so any queued position to the right then referred to a different pair, failed revalidation and was discarded — and only `idx-1/idx/idx+1` were re-queued, so a pending merge separated from the merge point by unmergeable tokens was lost permanently.

Against the real Qwen2 vocabulary this shredded 9 of 20 common words, with the correct token present in the vocab every time:

```
" helpful"     vocab 10950  ->  Ġhelp|fu|l
" assistant"   vocab 17847  ->  Ġass|is|ta|nt
" information" vocab  1995  ->  Ġinfo|rm|atio|n
" beautiful"   vocab  6233  ->  Ġbeau|ti|fu|l
```

`decode(encode(x)) == x` still held, which is why it went unnoticed — the text round-tripped, only the ids were wrong. "You are a helpful assistant." was 11 ids instead of 6.

`ApplySentencePieceMerges` (Llama/Gemma path) had the same shift bug and additionally never revalidated the score, so a shifted index could merge a pair that was never queued. Both now use stable slot indices and rebuild the list at the end.

## 3. GGUF loader: mis-mapped tensor and an int32 overflow

`ResolveTarget` matched the token embedding by substring, so gemma-3n/gemma-4's separate `per_layer_token_embd.weight` matched too:

```
per_layer_token_embd.weight  shape=[8960,262144]  2,348,810,240 elements -> int32 -1946157056
token_embd.weight            shape=[1536,262144]    402,653,184 elements   (the real one)
```

That overflowed the int element count and surfaced far from the cause as `ArrayPool.Rent(-1946157056)`. Even with unlimited memory it was wrong — it would have dequantized a foreign tensor over the embedding table. Now `per_layer` is excluded, element counts are `long`, and an oversized tensor throws a `NotSupportedException` naming the tensor instead of wrapping negative.

gemma-4-E2B now loads and builds where it previously threw. It generates 0 tokens because the per-layer-embedding architecture is unimplemented — that is a separate feature, not this fix.

Also included: `LoadSingleTensor` always dequantized into a rented float buffer before deciding whether anything wanted the result. In streaming mode the 2D weight tensors are deliberately null so the quantized forward can read raw bytes, so every layer of every forward dequantized the full attention and FFN weights and discarded them. Skipping that when there is no float target cuts streaming generation of 6 tokens from **10.54s to 6.18s**, with identical output ids in both load modes.

## Verification

- Tests assert both rotary conventions against hand-computed rotations, that they diverge at non-zero positions, that position 0 is the identity for both, and the architecture mapping.
- BPE regression test covers the case the old code lost (`"abzzzef"`, where the `(e,f)` merge sits three unmergeable tokens right of the `(a,b)` merge); verified red without the fix, green with it.
- Suite 661/661 across 3 runs.
