### PR TITLE
Stop ChatSession disposing a model it was handed

### DIFF
--- a/SharpMind.CUI/App/SessionLauncher.cs
+++ b/SharpMind.CUI/App/SessionLauncher.cs
@@ -393,7 +393,13 @@ public static class SessionLauncher
             return new LaunchResult { Error = $"Failed to start session with {options.Generator}/{options.Cache}: {ex.Message}", Warnings = warnings };
         }
 
-        session.MaxTokens = options.Generation.MaxNewTokens;
+        // MaxNewTokens is the generation length; MaxTokens is the context window
+        // ChatSession.TrimToFitContext budgets against. Assigning the user's
+        // "max new tokens" to MaxTokens left generation stuck at its 256 default
+        // and shrank the context budget to (setting - 256), so history was evicted
+        // after a couple of turns and the model lost the conversation.
+        session.MaxNewTokens = options.Generation.MaxNewTokens;
+        session.MaxTokens = loaded.Model.Config.MaxSeqLen;
         session.Temperature = options.Sampling.Temperature;
         session.TopK = options.Sampling.TopK;
         session.TopP = options.Sampling.TopP;

--- a/SharpMind.Inference/Chat/ChatSession.cs
+++ b/SharpMind.Inference/Chat/ChatSession.cs
@@ -94,9 +94,10 @@ public sealed class ChatSession<T, K> : IChatSession where K : IKVCacheBuilder, 
     /// tool call is gated through the callback.
     /// </param>
     /// <param name="disposeModel">
-    /// When <see langword="false"/> the session disposes its generator but
-    /// leaves the underlying <see cref="Transformer"/> alive, so multiple
-    /// fresh sessions can share one loaded model.
+    /// Whether disposing the session also disposes the <see cref="Transformer"/>
+    /// passed in. Defaults to <see langword="false"/>: the caller constructed the
+    /// model, so the caller owns it, and multiple sessions can share one loaded
+    /// model. Pass <see langword="true"/> only to hand ownership over.
     /// </param>
     public int MaxToolCallsPerTurn { get; set; } = 10;
     /// <summary>Maximum sub-agent nesting depth. Default 2. Reached when both parent and one sub-agent are active.</summary>
@@ -113,7 +114,7 @@ public sealed class ChatSession<T, K> : IChatSession where K : IKVCacheBuilder, 
         IKVCache[]? caches = null,
         IChatPromptFormatter? formatter = null,
         int? seed = null,
-        bool disposeModel = true)
+        bool disposeModel = false)
     {
         ArgumentNullException.ThrowIfNull(tokenizer);
         ArgumentNullException.ThrowIfNull(model);
@@ -1096,9 +1097,12 @@ private void ThrowIfDisposed()
                 if (token.IsCancellationRequested) break;
                 continue;
             }
-            catch
+            catch (Exception ex)
             {
-                response(new ChatStreamEntry { Status = ChatStatus.Interrupted, IsComplete = true, TokensPerSecond = _generator.TokensPerSecond, TimeToFirstToken = _generator.TimeToFirstToken });
+                // Still caught so a host UI is not torn down by a bad turn, but the
+                // reason travels with the entry now: swallowing it made an internal
+                // failure look identical to an empty answer.
+                response(new ChatStreamEntry { Status = ChatStatus.Interrupted, IsComplete = true, TokensPerSecond = _generator.TokensPerSecond, TimeToFirstToken = _generator.TimeToFirstToken, Error = $"{ex.GetType().Name}: {ex.Message}" });
                 break;
             }
 

--- a/SharpMind.Inference/Chat/ChatSessionFactory.cs
+++ b/SharpMind.Inference/Chat/ChatSessionFactory.cs
@@ -12,19 +12,23 @@ namespace SharpMind.Inference.Chat
         public static IChatSession CreateChatSession(
             Type generatorBuilderDef,  // typeof(StandardGeneratorBuilder<>)
             Type cacheBuilder,         // typeof(KVCacherBuilder)
-            Transformer model, Tokenizer tokenizer, ModelMetaData? meta = null, IAgentBuilder? agentBuilder = null, IPromptPreProcessor? preProcessor = null, IPromptPostProcessor? postProcessor = null, IProgress<float>? progress = null, Func<ToolPermissionContext, Task<ToolPermission>>? permissions = null, IChatPromptFormatter? formatter = null, int? seed = null)
+            Transformer model, Tokenizer tokenizer, ModelMetaData? meta = null, IAgentBuilder? agentBuilder = null, IPromptPreProcessor? preProcessor = null, IPromptPostProcessor? postProcessor = null, IProgress<float>? progress = null, Func<ToolPermissionContext, Task<ToolPermission>>? permissions = null, IChatPromptFormatter? formatter = null, int? seed = null, bool disposeModel = false)
         {
             var closedGen = generatorBuilderDef.IsGenericTypeDefinition
                 ? generatorBuilderDef.MakeGenericType(cacheBuilder)
                 : generatorBuilderDef;
             var sessionType = typeof(ChatSession<,>).MakeGenericType(closedGen, cacheBuilder);
-            return (IChatSession)Activator.CreateInstance(sessionType, [model, tokenizer, meta, agentBuilder, preProcessor, postProcessor, progress, permissions, null,formatter, seed,true])!;
+            // disposeModel defaults false: the caller loaded the model and keeps it
+            // across sessions. This used to be hardcoded true, so ending one chat
+            // disposed the shared Transformer and every later session threw
+            // ObjectDisposedException — swallowed and shown as an empty reply.
+            return (IChatSession)Activator.CreateInstance(sessionType, [model, tokenizer, meta, agentBuilder, preProcessor, postProcessor, progress, permissions, null, formatter, seed, disposeModel])!;
         }
         // Compile-time — for known type combos
         public static ChatSession<T, K> CreateChatSession<T, K>(
-            Transformer model, Tokenizer tokenizer, ModelMetaData? meta = null, IAgentBuilder? agentBuilder = null, IPromptPreProcessor? preProcessor = null, IPromptPostProcessor? postProcessor = null, IProgress<float>? progress = null, Func<ToolPermissionContext, Task<ToolPermission>>? permissions = null, IChatPromptFormatter? formatter = null, int? seed = null)
+            Transformer model, Tokenizer tokenizer, ModelMetaData? meta = null, IAgentBuilder? agentBuilder = null, IPromptPreProcessor? preProcessor = null, IPromptPostProcessor? postProcessor = null, IProgress<float>? progress = null, Func<ToolPermissionContext, Task<ToolPermission>>? permissions = null, IChatPromptFormatter? formatter = null, int? seed = null, bool disposeModel = false)
             where K : IKVCacheBuilder, new()
             where T : IGeneratorBuilder<K>, new()
-            => new(model, tokenizer, meta, agentBuilder, preProcessor, postProcessor, progress, permissions, null,formatter, seed);
+            => new(model, tokenizer, meta, agentBuilder, preProcessor, postProcessor, progress, permissions, null, formatter, seed, disposeModel);
     }
 }

--- a/SharpMind.Inference/Chat/ChatStreamEntry.cs
+++ b/SharpMind.Inference/Chat/ChatStreamEntry.cs
@@ -21,4 +21,12 @@ public sealed class ChatStreamEntry
 
     /// <summary>Seconds from start to first output token (includes prefill).</summary>
     public float? TimeToFirstToken { get; init; }
+
+    /// <summary>
+    /// Set when generation ended because of an unexpected exception rather than
+    /// a user interruption. Without this an internal failure was indistinguishable
+    /// from a cancelled turn — it surfaced as an empty reply and nothing else.
+    /// Null for normal streaming and for genuine cancellation.
+    /// </summary>
+    public string? Error { get; init; }
 }

--- a/SharpMind.Inference/Chat/IChatSession.cs
+++ b/SharpMind.Inference/Chat/IChatSession.cs
@@ -4,7 +4,15 @@ using SharpMind.Tokenization;
 namespace SharpMind.Inference.Chat;
 public interface IChatSession : IAsyncDisposable
 {
+    /// <summary>Context window the prompt is trimmed to fit, in tokens.</summary>
     public int MaxTokens { get; set; }
+
+    /// <summary>
+    /// Maximum tokens generated per turn. Distinct from <see cref="MaxTokens"/>,
+    /// which is the context budget — setting the generation length on MaxTokens
+    /// instead leaves generation at its default and starves the context.
+    /// </summary>
+    public int MaxNewTokens { get; set; }
     public float Temperature { get; set; }
     public int TopK { get; set; }
     public float TopP { get; set; }

--- a/SharpMind.Tests/Inference/ChatSessionModelOwnershipTests.cs
+++ b/SharpMind.Tests/Inference/ChatSessionModelOwnershipTests.cs
@@ -1,0 +1,116 @@
+using SharpMind.Core;
+using SharpMind.Core.Tensors;
+using SharpMind.Inference;
+using SharpMind.Inference.Chat;
+using SharpMind.Model;
+using SharpMind.Model.Config;
+using SharpMind.Tokenization;
+using SharpMind.Tokenization.Vocab;
+using SharpMind.Training;
+using Xunit;
+
+namespace SharpMind.Tests.Inference;
+
+/// <summary>
+/// A ChatSession must not dispose a Transformer it was handed. The default used
+/// to be disposeModel: true, and ChatSessionFactory hardcoded true, so ending one
+/// chat disposed the caller's shared model. Every later session then threw
+/// ObjectDisposedException inside generation, which StartChatAsync's bare catch
+/// swallowed — the user saw an empty reply and no error.
+/// </summary>
+public sealed class ChatSessionModelOwnershipTests
+{
+    private static ModelConfig Cfg => new()
+    {
+        VocabSize = 300,
+        HiddenDim = 8,
+        NumLayers = 1,
+        NumHeads = 2,
+        NumKvHeads = 2,
+        FfnDim = 16,
+        MaxSeqLen = 32,
+    };
+
+    private static Tokenizer BuildTokenizer()
+    {
+        var tokens = new List<string> { "[UNK]", "[BOS]", "[EOS]" };
+        for (int b = 0; b < 256; b++) tokens.Add(Vocabulary.ByteTokenString(b));
+        return Tokenizer.FromGguf([.. tokens], merges: null, tokenTypes: null, bosId: 1, eosId: 2);
+    }
+
+    private static Transformer BuildModel()
+    {
+        var sharpConfig = SharpMindConfig.Gpt with { Hardware = HardwareTier.Scalar };
+        var weights = ModelFactory.CreateForTraining(Cfg, sharpConfig);
+        WeightInitializer.InitializeRandomly(weights, 1234);
+        return ModelFactory.CreateTrainingTransformer(weights, sharpConfig);
+    }
+
+    private static void AssertModelUsable(Transformer model)
+    {
+        using var input = Tensor<int>.From([1, 2, 3], 1, 3);
+        using var logits = model.Forward(input, null, 0, null);
+        Assert.Equal(Cfg.VocabSize, logits.Shape[^1]);
+    }
+
+    [Fact]
+    public async Task DisposingSession_LeavesCallerOwnedModelUsable()
+    {
+        using var model = BuildModel();
+        var tokenizer = BuildTokenizer();
+
+        await using (var session = new ChatSession<StandardGeneratorBuilder<KVCacherBuilder>, KVCacherBuilder>(
+            model, tokenizer))
+        {
+            session.InitializeChat();
+        }
+
+        AssertModelUsable(model);
+    }
+
+    [Fact]
+    public async Task SecondSession_CanBeBuiltOnTheSameModel()
+    {
+        using var model = BuildModel();
+        var tokenizer = BuildTokenizer();
+
+        for (int i = 0; i < 3; i++)
+        {
+            await using var session = new ChatSession<StandardGeneratorBuilder<KVCacherBuilder>, KVCacherBuilder>(
+                model, tokenizer);
+            session.InitializeChat();
+            AssertModelUsable(session.Model);
+        }
+    }
+
+    [Fact]
+    public async Task Factory_DoesNotTakeOwnershipByDefault()
+    {
+        using var model = BuildModel();
+        var tokenizer = BuildTokenizer();
+
+        await using (var session = ChatSessionFactory.CreateChatSession(
+            typeof(StandardGeneratorBuilder<>), typeof(KVCacherBuilder), model, tokenizer))
+        {
+            session.InitializeChat();
+        }
+
+        AssertModelUsable(model);
+    }
+
+    [Fact]
+    public async Task DisposeModelTrue_StillTransfersOwnership()
+    {
+        var model = BuildModel();
+        var tokenizer = BuildTokenizer();
+
+        await using (var session = new ChatSession<StandardGeneratorBuilder<KVCacherBuilder>, KVCacherBuilder>(
+            model, tokenizer, disposeModel: true))
+        {
+            session.InitializeChat();
+        }
+
+        using var input = Tensor<int>.From([1, 2, 3], 1, 3);
+        Assert.Throws<ObjectDisposedException>(() => model.Forward(input, null, 0, null));
+    }
+}


### PR DESCRIPTION
A `ChatSession` disposed a `Transformer` it was handed, so only the first chat on a loaded model worked.

## The bug

`ChatSession`'s constructor defaulted to `disposeModel: true` and `ChatSessionFactory` hardcoded `true`, so disposing a session disposed the caller's model. Every later session then threw `ObjectDisposedException` from `Transformer.ThrowIfDisposed` inside generation.

That exception was invisible. `StartChatAsync` ends with a bare `catch` that reports any failure as `ChatStatus.Interrupted`, so the user saw an empty reply, in 0.0s, with no error anywhere:

```
before:  session 1  "What is the capital of France?"  -> "The capital of France is Paris."
         session 2  "What is 2 + 2?"                  -> ""   (0.0s)
         session 3  "Name one colour."                -> ""   (0.0s)

after:   session 1 -> "The capital of France is Paris."
         session 2 -> "The sum of 2 and 2 is 4."
         session 3 -> "Red"
```

Three call sites had already worked around the default by passing `disposeModel: false`, one with the comment *"keeps the model alive so later prompts"* — the default was the thing that was wrong. Every sample owns its model with `using var model`, so flipping it also removes a double dispose. Callers that genuinely want to hand ownership over can still pass `disposeModel: true`.

## Also in this PR

- **`ChatStreamEntry.Error`**, set by that bare catch. The catch still swallows so a host UI is not torn down by one bad turn, but the reason now travels with the entry instead of an internal failure being indistinguishable from an empty answer.
- **`IChatSession` exposes `MaxNewTokens`.** It only had `MaxTokens`, which invited the next item.
- **`SessionLauncher` conflated the two.** It assigned the user's "max new tokens" setting to `session.MaxTokens` — the *context window* that `TrimToFitContext` budgets against — and never set `MaxNewTokens`. Generation was therefore pinned at its 256 default regardless of the setting, and the context budget became `(setting - 256)`, so history was evicted after a couple of turns and the model lost the conversation. `MaxNewTokens` now takes the setting and `MaxTokens` takes the model's context length.

Multi-turn within one session was verified correct once the two properties are used as intended: history grows 2 → 4 → 6 and a follow-up resolves against earlier turns ("What country is it in?" answers about France).

## Verification

Tests cover session disposal leaving the caller's model usable, three sequential sessions on one model, the factory not taking ownership, and `disposeModel: true` still transferring it. Verified red without the change (3 of 4 fail), green with it.

## Note on CI

One test, `SmmExportLoadTests.TrainingExport_MoE_ReloadsWithParity`, fails on this branch. It fails on `master` too — a pre-existing data race fixed in the sibling PR "Fix data race on TrainingLinearLayer's transposed weight". Nothing here touches it.
