### PR TITLE
Halve inference memory, validate weights at load, and prefill long prompts in chunks

### DIFF
--- a/SharpMind.CUI/App/SessionLauncher.cs
+++ b/SharpMind.CUI/App/SessionLauncher.cs
@@ -159,7 +159,10 @@ public static class SessionLauncher
             var qOps = QuantizationFactory.Create(mapping);
             weights = await Task.Run(() =>
             {
-                var w = ModelFactory.CreateWeights(modelConfig, sharpConfig, qOps, options.ModelPath, options.LoadMode);
+                // Chat only ever runs the quantized forward, which reads the raw
+                // bytes, so skip the dequantized F32 copy of every layer.
+                var w = ModelFactory.CreateWeights(modelConfig, sharpConfig, qOps, options.ModelPath, options.LoadMode,
+                    quantizedResident: true);
                 w.InitializeWeights(progress);
                 return w;
             },ct);

--- a/SharpMind.CUI/ChatView.cs
+++ b/SharpMind.CUI/ChatView.cs
@@ -53,6 +53,7 @@ public sealed class ChatView : View
     private string? _activeSubAgentName;
     private bool _generating;
     private bool _interruptDialogOpen;
+    private bool _faultReported;
     private object? _timeoutToken;
     private bool _disposed;
 
@@ -421,6 +422,18 @@ public sealed class ChatView : View
         foreach (var entry in _bridge.DrainEntries())
             OnStreamEntry(entry);
 
+        // A fault kills the bridge's whole session loop, so nothing further
+        // will ever arrive on the queue. Without this the screen just sits on
+        // "Thinking..." forever with no clue why.
+        if (_bridge.Faulted && !_faultReported)
+        {
+            _faultReported = true;
+            if (_liveResponse.Length > 0) CommitLiveResponse();
+            AppendTranscript($"[session stopped: {_bridge.Fault?.Message ?? "unknown error"}]");
+            SetGenerating(false);
+            _statusLabel.Text = "Failed";
+        }
+
         if (_cuiContext?.TakePending() is { } request)
             ShowChoiceDialog(request);
 
@@ -478,6 +491,11 @@ public sealed class ChatView : View
         {
             if (_liveResponse.Length > 0)
                 CommitLiveResponse();
+            // ChatSession catches a failed turn and reports the reason on the
+            // entry rather than tearing the UI down. Dropping it here made an
+            // internal failure look exactly like an empty answer.
+            if (entry.Error is { Length: > 0 } error)
+                AppendTranscript($"[error: {error}]");
             SetGenerating(false);
             _toolLabel.Text = "Tool: none";
             _pendingSpeakerName = null;

--- a/SharpMind.Core/Embeddings/RoPE.cs
+++ b/SharpMind.Core/Embeddings/RoPE.cs
@@ -42,11 +42,20 @@ public sealed class RoPE : PositionalEncoder
     /// <param name="ropeOriginalContextLength">Original context length before scaling (NTK-by-parts).</param>
     /// <param name="lowFreqFactor">NTK-by-parts low frequency factor (llama3).</param>
     /// <param name="highFreqFactor">NTK-by-parts high frequency factor (llama3).</param>
+    /// <summary>
+    /// True = NeoX/"rotate_half" pairing (d, d + ropeDim/2); false = adjacent
+    /// pairing (2i, 2i+1). llama.cpp picks this per architecture: LLaMA-family
+    /// GGUFs are converted with Q/K permuted so adjacent pairing is correct,
+    /// while Qwen/Gemma/Phi/StableLM/GPT-NeoX are not permuted and need NeoX.
+    /// </summary>
+    private readonly bool _neoxStyle;
+
     public RoPE(int headDim, int maxSeqLen, float theta = 10_000f,
         int? ropeDim = null, string? ropeScalingType = null, float? ropeScalingFactor = null,
         int? ropeOriginalContextLength = null, float? lowFreqFactor = null, float? highFreqFactor = null,
-        float[]? precomputedFreqs = null)
+        float[]? precomputedFreqs = null, bool neoxStyle = false)
     {
+        _neoxStyle = neoxStyle;
         if (headDim % 2 != 0)
             throw new ArgumentException($"HeadDim must be even, got {headDim}.");
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxSeqLen);
@@ -174,6 +183,24 @@ public sealed class RoPE : PositionalEncoder
             {
                 int offset = (s * numHead + h) * _headDim;
 
+                if (_neoxStyle)
+                {
+                    // NeoX / HF "rotate_half": pair dimension d with d + ropePairs.
+                    // ponytail: scalar only — correctness first; vectorise like the
+                    // adjacent path below if this shows up in a profile.
+                    for (int d = 0; d < ropePairs; d++)
+                    {
+                        float cosN = _cosCache[cacheBase + d];
+                        float sinN = _sinCache[cacheBase + d];
+                        float a = data[offset + d];
+                        float bHalf = data[offset + d + ropePairs];
+
+                        data[offset + d] = a * cosN - bHalf * sinN;
+                        data[offset + d + ropePairs] = bHalf * cosN + a * sinN;
+                    }
+                    continue;
+                }
+
                 // Adjacent-pairing (matches llama.cpp / ggml):
                 // pairs are (data[2i], data[2i + 1]) for i = 0..ropePairs-1,
                 // rotated by angle pos * theta^{-2i/_ropeDim}.
@@ -278,6 +305,21 @@ public sealed class RoPE : PositionalEncoder
             for (int h = 0; h < numHead; h++)
             {
                 int offset = (s * numHead + h) * _headDim;
+
+                if (_neoxStyle)
+                {
+                    for (int d = 0; d < ropePairs; d++)
+                    {
+                        float cosN = _cosCache[cacheBase + d];
+                        float sinN = _sinCache[cacheBase + d];
+                        float g0 = data[offset + d];
+                        float g1 = data[offset + d + ropePairs];
+
+                        data[offset + d] = cosN * g0 + sinN * g1;
+                        data[offset + d + ropePairs] = -sinN * g0 + cosN * g1;
+                    }
+                    continue;
+                }
 
                 for (int i = 0; i < ropePairs; i++)
                 {

--- a/SharpMind.Core/Embeddings/RoPE.cs
+++ b/SharpMind.Core/Embeddings/RoPE.cs
@@ -23,7 +23,18 @@ namespace SharpMind.Core.Embeddings;
 /// </summary>
 public sealed class RoPE : PositionalEncoder
 {
-    private static readonly ConcurrentDictionary<int, (float[] cos, float[] sin)> TableCache = [];
+    /// <summary>
+    /// Identifies one set of cos/sin tables. Keyed by the values themselves, not
+    /// by HashCode.Combine of them: a hash is 32 bits and collides, and a
+    /// collision here silently hands a model another configuration's rotary
+    /// tables. neoxStyle is deliberately absent — it changes how the tables are
+    /// applied, not their contents.
+    /// </summary>
+    private readonly record struct TableKey(
+        float Theta, int RopeDim, int MaxSeqLen, float? ScalingFactor,
+        string? ScalingType, int? OriginalContextLength, float? LowFreqFactor, float? HighFreqFactor);
+
+    private static readonly ConcurrentDictionary<TableKey, (float[] cos, float[] sin)> TableCache = [];
     private readonly float[] _cosCache; // [MaxSeqLen, HeadDim/2]
     private readonly float[] _sinCache;
     private readonly int     _headDim;
@@ -86,7 +97,7 @@ public sealed class RoPE : PositionalEncoder
         else
         {
             (_cosCache, _sinCache) = TableCache.GetOrAdd(
-                HashCode.Combine(theta, halfDim, _maxSeqLen, ropeScalingFactor, ropeScalingType,
+                new TableKey(theta, _ropeDim, _maxSeqLen, ropeScalingFactor, ropeScalingType,
                     ropeOriginalContextLength, lowFreqFactor, highFreqFactor), (b) =>
             {
                 var cos = new float[_maxSeqLen * halfDim];

--- a/SharpMind.Core/Memory/Workspace.cs
+++ b/SharpMind.Core/Memory/Workspace.cs
@@ -17,6 +17,15 @@ public sealed unsafe class Workspace : IDisposable
     private long _offset;
     private readonly long _capacity;
 
+    /// <summary>
+    /// Tokens a single forward pass may carry. The workspace is sized for
+    /// exactly this many (see <see cref="CalculateRequiredSize"/>), so a
+    /// prompt longer than this must be prefilled in chunks of at most this
+    /// size — see <c>Transformer.PrefillLastLogits</c>. Sizing for a full
+    /// context window instead would need tens of gigabytes.
+    /// </summary>
+    public const int MaxPrefillTokens = 128;
+
     public Workspace(long capacityBytes)
     {
         _capacity = capacityBytes;
@@ -92,9 +101,11 @@ public sealed unsafe class Workspace : IDisposable
     /// The LM head output is a fixed [Batch, VocabSize] tensor (not per-token),
     /// allocated once per forward pass independent of sequence length.
     ///
-    /// The prefill length used for sizing is capped to keep the workspace under
-    /// ~1 GiB. The workspace is primarily sized for the decode hot loop (1 token);
-    /// the prefill path for long prompts is handled by the generator.
+    /// The prefill length used for sizing is capped at
+    /// <see cref="MaxPrefillTokens"/> to keep the workspace under ~1 GiB. A
+    /// prompt longer than that must therefore be fed through in chunks of at
+    /// most that size — <c>Transformer.PrefillLastLogits</c> is the one place
+    /// that does it, and every generator prefills through it.
     /// </summary>
     public static long CalculateRequiredSize(long hiddenDim, long ffnDim, long vocabSize, int numLayers, int maxSeqLen)
     {
@@ -119,7 +130,7 @@ public sealed unsafe class Workspace : IDisposable
         long fixedFloats = vocabSize;
 
         // Cap prefill length to keep workspace under ~1 GiB for most models.
-        int effectivePrefillLen = Math.Min(maxSeqLen, 128);
+        int effectivePrefillLen = Math.Min(maxSeqLen, MaxPrefillTokens);
         long total = (perTokenFloats * effectivePrefillLen + fixedFloats) * bytesPerFloat;
 
         // Minimum 100MB to cover small-batch / short-prompt overheads.

--- a/SharpMind.Inference/MedusaGenerator.cs
+++ b/SharpMind.Inference/MedusaGenerator.cs
@@ -183,14 +183,12 @@ public sealed class MedusaGenerator<T> : IGenerator<T> where T : IKVCacheBuilder
         int draftLen = numHeads + 1; // LM-head greedy + K head predictions
 
         // Prefill
-        // Process the full prompt in one go.  After this, the KV cache has
-        // promptLen entries and logitsTensor predicts the very next token.
+        // Process the whole prompt, in workspace-sized chunks. After this, the
+        // KV cache has promptLen entries and logitsTensor predicts the very
+        // next token.
         _workspace.Reset();
         int posOffset = _caches[0].Length;
-        using var prefillInput = _workspace.Rent<int>([1, promptIds.Length]);
-        promptIds.CopyTo(prefillInput.Data);
-        Tensor<float>? logitsTensor = _model.ForwardLastLogits(
-            prefillInput, _caches, posOffset, _workspace);
+        Tensor<float>? logitsTensor = _model.PrefillLastLogits(promptIds, _caches, posOffset, _workspace);
 
         try
         {

--- a/SharpMind.Inference/SpeculativeGenerator.cs
+++ b/SharpMind.Inference/SpeculativeGenerator.cs
@@ -98,9 +98,8 @@ public sealed class SpeculativeGenerator<T> : IGenerator<T> where T : IKVCacheBu
         rateTracker.Start();
 
         int posOffset = _caches[0].Length;
-        using var prefillInput = Tensor<int>.From(promptIds, 1, promptIds.Length);
         _workspace?.Reset();
-        Tensor<float>? logitsTensor = _model.ForwardLastLogits(prefillInput, _caches, posOffset, _workspace);
+        Tensor<float>? logitsTensor = _model.PrefillLastLogits(promptIds, _caches, posOffset, _workspace);
 
         try
         {

--- a/SharpMind.Inference/StandardGenerator.cs
+++ b/SharpMind.Inference/StandardGenerator.cs
@@ -107,12 +107,11 @@ public sealed class StandardGenerator<T> : IGenerator<T> where T : IKVCacheBuild
         Tensor<float>? logitsTensor = null;
         try
         {
-            // Prefill
+            // Prefill — chunked, because the workspace only holds
+            // Workspace.MaxPrefillTokens tokens per forward pass.
             _workspace.Reset();
             int posOffset = _caches[0].Length;
-            using var prefillInput = _workspace.Rent<int>([1, promptIds.Length]);
-            promptIds.CopyTo(prefillInput.Data);
-                logitsTensor = _model.ForwardLastLogits(prefillInput, _caches, posOffset, _workspace);
+            logitsTensor = _model.PrefillLastLogits(promptIds, _caches, posOffset, _workspace);
 
 
             int vocabSize = logitsTensor.Shape[1];

--- a/SharpMind.Model/Format/GgufLoader.cs
+++ b/SharpMind.Model/Format/GgufLoader.cs
@@ -609,7 +609,17 @@ public sealed class GgufLoader(QuantizationOps qOps, string path, ModelConfig co
             }
         }
 
-        // Dequantize to float
+        // Dequantize to float — but only if something will consume the floats.
+        // In streaming mode the 2D weight tensors are deliberately left null and
+        // the quantized forward reads the raw bytes instead, so dequantizing here
+        // did full work per layer per forward pass and discarded every value.
+        // Each tensor is seeked to explicitly above, so skipping reads nothing
+        // the next tensor depends on.
+        Tensor<float>? blockFloatTarget = target == null && block != null
+            ? weights.ResolveFloatTarget(info.Name)
+            : null;
+        if (target == null && blockFloatTarget == null) return;
+
         float[] buffer = ArrayPool<float>.Shared.Rent(count);
         try
         {
@@ -631,7 +641,7 @@ public sealed class GgufLoader(QuantizationOps qOps, string path, ModelConfig co
             }
             else if (block != null)
             {
-                var floatTarget = weights.ResolveFloatTarget(info.Name);
+                var floatTarget = blockFloatTarget;
                 if (floatTarget != null)
                 {
                     if (info.Shape.Length == 2)

--- a/SharpMind.Model/Format/GgufLoader.cs
+++ b/SharpMind.Model/Format/GgufLoader.cs
@@ -546,8 +546,17 @@ public sealed class GgufLoader(QuantizationOps qOps, string path, ModelConfig co
         if (targetOffset >= stream.Length) return;
         stream.Position = targetOffset;
 
-        int count = 1;
-        foreach (int d in info.Shape) count *= d;
+        // long: a tensor can hold more elements than int can count (gemma-3n's
+        // per-layer embeddings are 2.3e9), and silently wrapping negative here
+        // surfaced far away as ArrayPool.Rent(-1946157056).
+        long longCount = 1;
+        foreach (int d in info.Shape) longCount *= d;
+        if (longCount > int.MaxValue)
+            throw new NotSupportedException(
+                $"Tensor '{info.Name}' has {longCount:N0} elements, more than this loader can " +
+                $"dequantize into a single float buffer (max {int.MaxValue:N0}). " +
+                "Shape: [" + string.Join(",", info.Shape) + "].");
+        int count = (int)longCount;
 
         // Load raw quantized data for block-level tensors
         if (block != null && rawField != null && rawSize > 0 && stream.Position + rawSize <= stream.Length)
@@ -654,8 +663,13 @@ public sealed class GgufLoader(QuantizationOps qOps, string path, ModelConfig co
 
     private void ReadTensorInto(BinaryReader stream, QuantDType dtype, int[] shape, Span<float> destination)
     {
-        int count = 1;
-        foreach (int d in shape) count *= d;
+        long longCount = 1;
+        foreach (int d in shape) longCount *= d;
+        if (longCount > int.MaxValue)
+            throw new NotSupportedException(
+                $"Tensor with shape [{string.Join(",", shape)}] has {longCount:N0} elements, " +
+                $"more than a single float buffer can hold (max {int.MaxValue:N0}).");
+        int count = (int)longCount;
         if (destination.Length < count) throw new ArgumentException($"Destination buffer too small: {destination.Length} < {count}");
         _qOps.ReadFor(dtype, stream, destination, count);
     }

--- a/SharpMind.Model/Layers/Attention/AttentionLayer.cs
+++ b/SharpMind.Model/Layers/Attention/AttentionLayer.cs
@@ -114,7 +114,32 @@ namespace SharpMind.Model.Layers.Attention;
                  ropeOriginalContextLength: config.RopeOriginalContextLength,
                  lowFreqFactor: config.RopeLowFreqFactor,
                  highFreqFactor: config.RopeHighFreqFactor,
-                 precomputedFreqs: config.PrecomputedRopeFreqs),
+                 precomputedFreqs: config.PrecomputedRopeFreqs,
+                 neoxStyle: UsesNeoxRope(config.Architecture)),
+        };
+    }
+
+    /// <summary>
+    /// Which rotary convention a GGUF architecture expects. llama.cpp fixes this
+    /// per architecture rather than storing it in the file: LLaMA-family models
+    /// are converted with their Q/K weights permuted, so adjacent (2i, 2i+1)
+    /// pairing reproduces HF's rotate_half; the architectures below are NOT
+    /// permuted at conversion and need true NeoX (d, d + ropeDim/2) pairing.
+    /// Getting this wrong leaves the model locally fluent but unable to use
+    /// position — it repeats and cannot recall facts from earlier tokens.
+    /// Unknown architectures keep the previous adjacent behaviour.
+    /// </summary>
+    public static bool UsesNeoxRope(string? architecture)
+    {
+        if (string.IsNullOrWhiteSpace(architecture)) return false;
+
+        return architecture.ToLowerInvariant() switch
+        {
+            "qwen" or "qwen2" or "qwen2moe" or "qwen3" or "qwen3moe" => true,
+            "gemma" or "gemma2" or "gemma3" => true,
+            "phi2" or "phi3" => true,
+            "stablelm" or "gptneox" or "starcoder2" or "olmo2" or "nemotron" or "exaone" => true,
+            _ => false,
         };
     }
 

--- a/SharpMind.Model/Layers/InferenceLinearLayer.cs
+++ b/SharpMind.Model/Layers/InferenceLinearLayer.cs
@@ -208,6 +208,24 @@ public abstract class InferenceLinearLayer : LinearLayer
 
     public override void SetRawWeight(byte[]? rawData)
     {
+        // Check on arrival, not at the first matmul. The same mismatch used to
+        // surface deep inside a forward pass after the model had "loaded"
+        // successfully, which reads as a runtime failure rather than what it is:
+        // a model whose tensor shapes do not match the architecture we derived
+        // from its config. Forward keeps its own guard as defence in depth.
+        if (rawData is not null)
+        {
+            long expectedBytes = QuantizationOps.GetRawTensorByteCount([OutFeatures, InFeatures], QuantDtype);
+            if (rawData.Length != expectedBytes)
+                throw new NotSupportedException(
+                    $"[{Name}] weight shape does not match this architecture: dtype={QuantDtype}, " +
+                    $"K={InFeatures}, N={OutFeatures} expects {expectedBytes} bytes but the model " +
+                    $"provides {rawData.Length}. The file's tensor is " +
+                    $"{(expectedBytes % rawData.Length == 0 ? $"1/{expectedBytes / rawData.Length} of" : "not")} " +
+                    "the expected size, so the layer dimensions derived from the model config are wrong " +
+                    "for this architecture. Loading it would produce garbage or read past the buffer.");
+        }
+
         RawQuantizedData = rawData;
     }
 }

--- a/SharpMind.Model/Layers/InferenceLinearLayer.cs
+++ b/SharpMind.Model/Layers/InferenceLinearLayer.cs
@@ -173,19 +173,7 @@ public abstract class InferenceLinearLayer : LinearLayer
         }
 
         if (_bias is not null)
-        {
-            if (workspace != null)
-            {
-                var biasB = workspace.Rent<float>([batchSize, OutFeatures]);
-                for (int i = 0; i < batchSize; i++)
-                    _bias!.Data.CopyTo(biasB.RowSpan(i));
-                result.AddInPlace(biasB);
-            }
-            else
-            {
-                result.AddInPlace(BroadcastBias(batchSize));
-            }
-        }
+            AddBiasInPlace(result, batchSize);
         if (needReshape)
         {
             Span<int> outDims = stackalloc int[input.Rank];

--- a/SharpMind.Model/Layers/Linearlayer.cs
+++ b/SharpMind.Model/Layers/Linearlayer.cs
@@ -121,12 +121,28 @@ public abstract class LinearLayer : IDisposable
         if (_ownsBias) _bias?.Dispose();
     }
 
-    protected Tensor<float> BroadcastBias(int batchSize)
+    /// <summary>
+    /// Adds the bias to every row of <paramref name="result"/> in place.
+    ///
+    /// This used to materialise the bias broadcast into a whole second
+    /// [batchSize, OutFeatures] tensor and then add tensor-to-tensor. For the
+    /// fused gate/up projection that duplicate is the single largest
+    /// allocation in a layer, and during prefill it pushed the forward pass
+    /// past the size Workspace.CalculateRequiredSize budgets for it — a long
+    /// prompt died with "Workspace capacity exceeded" in the last layers.
+    /// The add is O(batchSize × OutFeatures) against a matmul that is
+    /// O(batchSize × OutFeatures × InFeatures), so doing it row-wise costs
+    /// nothing measurable and allocates nothing at all.
+    /// </summary>
+    protected void AddBiasInPlace(Tensor<float> result, int batchSize)
     {
-        var broadcast = new Tensor<float>(batchSize, OutFeatures);
+        var bias = _bias!.Data;
         for (int i = 0; i < batchSize; i++)
-            _bias!.Data.CopyTo(broadcast.RowSpan(i));
-        return broadcast;
+        {
+            var row = result.RowSpan(i);
+            for (int j = 0; j < bias.Length; j++)
+                row[j] += bias[j];
+        }
     }
     private protected void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, nameof(LinearLayer));
 }

--- a/SharpMind.Model/Layers/TrainingLinearLayer.cs
+++ b/SharpMind.Model/Layers/TrainingLinearLayer.cs
@@ -91,21 +91,7 @@ private unsafe Tensor<float> MatMulForward(Tensor<float> input, int batchSize, W
         var output = MatMulForward(flat, batchSize, workspace);
 
         if (_bias is not null)
-        {
-            if (workspace != null)
-            {
-                var biasB = workspace.Rent<float>([batchSize, OutFeatures]);
-                for (int i = 0; i < batchSize; i++)
-                    _bias!.Data.CopyTo(biasB.RowSpan(i));
-                output.AddInPlace(biasB);
-            }
-            else
-            {
-                var biasBroadcast = BroadcastBias(batchSize);
-                output.AddInPlace(biasBroadcast);
-                biasBroadcast.Dispose();
-            }
-        }
+            AddBiasInPlace(output, batchSize);
         if (needReshape)
         {
             Span<int> outDims = stackalloc int[input.Rank];
@@ -140,7 +126,7 @@ var flat = needReshape ? input.Reshape(batchSize, InFeatures) : input;
                 fn(flat.DataPtr, rawPtr, output.DataPtr, batchSize, InFeatures, OutFeatures);
         }
         if (_bias is not null)
-            output.AddInPlace(BroadcastBias(batchSize));
+            AddBiasInPlace(output, batchSize);
         var state = new LinearLayerState(input, flat, needReshape, _weight);
         if (needReshape)
         {

--- a/SharpMind.Model/ModelFactory.cs
+++ b/SharpMind.Model/ModelFactory.cs
@@ -40,12 +40,20 @@ public static class ModelFactory
     /// <summary>Creates a <see cref="TransformerWeights"/> instance with a
     /// <see cref="GgufLoader"/> for the given path. Call <c>weights.InitializeWeights(progress)</c>
     /// after creation to populate weights from the GGUF file.</summary>
+    /// <param name="quantizedResident">
+    /// Skip allocating the per-layer F32 attention/FFN weights and keep only the
+    /// raw quantized bytes, which is all <see cref="InferenceLinearLayer"/>'s
+    /// forward reads. Roughly halves resident memory for a chat/inference load.
+    /// Leave false when the float tensors are needed after loading — SMM export
+    /// and format conversion read them back.
+    /// </param>
     public static TransformerWeights CreateWeights(
         ModelConfig modelConfig,
         SharpMindConfig sharpConfig,
         QuantizationOps qOps,
         string path,
-        LoadMode loadMode = LoadMode.Full)
+        LoadMode loadMode = LoadMode.Full,
+        bool quantizedResident = false)
     {
         ArgumentNullException.ThrowIfNull(modelConfig);
         ArgumentNullException.ThrowIfNull(sharpConfig);
@@ -56,34 +64,16 @@ public static class ModelFactory
         var finalNormW = Tensor<float>.Ones(modelConfig.HiddenDim);
         Tensor<float>? finalNormB = null;
 
-        TransformerWeights.BlockWeights[] blockWeights;
-        if (loadMode == LoadMode.Full)
-        {
-            blockWeights = AllocateBlockWeights(modelConfig, sharpConfig);
-        }
-        else
-        {
-            int kvDim = modelConfig.NumKvHeads * modelConfig.HeadDim;
-            int qDim = modelConfig.NumHeads * modelConfig.HeadDim;
-            blockWeights = new TransformerWeights.BlockWeights[modelConfig.NumLayers];
-            for (int i = 0; i < modelConfig.NumLayers; i++)
-            {
-                // Pre-allocate 1D tensors (norms, biases) that are needed as
-                // float targets by LoadSingleTensor and never streamed. The
-                // 2D weight tensors (attn, ffn) remain null — their raw
-                // quantized data is loaded per-layer and used directly by
-                // InferenceLinearLayer's quantized forward.
-                blockWeights[i] = new TransformerWeights.BlockWeights
-                {
-                    Norm1W = new Tensor<float>(modelConfig.HiddenDim),
-                    Norm2W = new Tensor<float>(modelConfig.HiddenDim),
-                    WqBias = new Tensor<float>(qDim),
-                    WkBias = new Tensor<float>(kvDim),
-                    WvBias = new Tensor<float>(kvDim),
-                    WoBias = new Tensor<float>(modelConfig.HiddenDim)
-                };
-            }
-        }
+        // Streaming has always left the 2D weights null; quantizedResident opts the
+        // Full path into the same thing. CreateTransformer builds
+        // InferenceLinearLayer, whose forward reads the raw quantized bytes and
+        // never touches the dequantized F32 duplicates, so for pure inference they
+        // cost ~4x the file size for nothing (3.57 GB before a byte was read, on a
+        // 0.49 GB model). It is opt-in because reading weights back as floats is a
+        // real use — SMM export and the conversion round-trip do exactly that.
+        var blockWeights = loadMode == LoadMode.Full && !quantizedResident
+            ? AllocateBlockWeights(modelConfig, sharpConfig)
+            : AllocateInferenceBlockWeights(modelConfig);
 
         var loader = ModelFormatHelpers.GetModelLoaderFor((ModelFormat)fmt, qOps, path, modelConfig);
 
@@ -99,6 +89,31 @@ public static class ModelFactory
         => config.PositionalEncoding == Config.PositionalEncoding.Learned
             ? new Tensor<float>(config.MaxSeqLen, config.HiddenDim)
             : null;
+
+    /// <summary>
+    /// Per-block tensors for inference: norms and biases only. The 2D weights are
+    /// left null so the quantized forward reads the raw bytes directly instead of
+    /// a dequantized F32 duplicate.
+    /// </summary>
+    private static TransformerWeights.BlockWeights[] AllocateInferenceBlockWeights(ModelConfig config)
+    {
+        int qDim = config.NumHeads * config.HeadDim;
+        int kvDim = config.NumKvHeads * config.HeadDim;
+        var blocks = new TransformerWeights.BlockWeights[config.NumLayers];
+        for (int i = 0; i < config.NumLayers; i++)
+        {
+            blocks[i] = new TransformerWeights.BlockWeights
+            {
+                Norm1W = new Tensor<float>(config.HiddenDim),
+                Norm2W = new Tensor<float>(config.HiddenDim),
+                WqBias = new Tensor<float>(qDim),
+                WkBias = new Tensor<float>(kvDim),
+                WvBias = new Tensor<float>(kvDim),
+                WoBias = new Tensor<float>(config.HiddenDim)
+            };
+        }
+        return blocks;
+    }
 
     private static TransformerWeights.BlockWeights[] AllocateBlockWeights(ModelConfig config, SharpMindConfig sharpConfig)
     {

--- a/SharpMind.Model/ModelFactory.cs
+++ b/SharpMind.Model/ModelFactory.cs
@@ -58,6 +58,7 @@ public static class ModelFactory
         ArgumentNullException.ThrowIfNull(modelConfig);
         ArgumentNullException.ThrowIfNull(sharpConfig);
         modelConfig.Validate();
+        ThrowIfArchitectureUnsupported(modelConfig.Architecture);
         var fmt = ModelFormatHelpers.GetFormatForExtension(path) ?? throw new FileLoadException($"File type not supported: {path}", path);
         var embedding = new Tensor<float>(modelConfig.VocabSize, modelConfig.HiddenDim);
         Tensor<float>? lmHead = null;
@@ -89,6 +90,44 @@ public static class ModelFactory
         => config.PositionalEncoding == Config.PositionalEncoding.Learned
             ? new Tensor<float>(config.MaxSeqLen, config.HiddenDim)
             : null;
+
+    /// <summary>
+    /// Architectures known NOT to work, with the reason. A denylist rather than an
+    /// allowlist on purpose: only entries actually observed to fail belong here, so
+    /// this can never reject a model that would have loaded.
+    ///
+    /// Without it these fail late and misleadingly — the generic decoder derives
+    /// layer shapes from the config, those shapes disagree with the file, and the
+    /// first matmul reports a byte-count mismatch as if the file were corrupt.
+    /// </summary>
+    private static readonly Dictionary<string, string> UnsupportedArchitectures = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Verified against gemma-4-{E2B,e4b,26B-A4B}-it-Q4_K_M. The family is
+        // gemma-3n-style and departs from a standard decoder in several ways at
+        // once, so correcting any single one only moves the failure along.
+        ["gemma4"] = "per-layer input embeddings (per_layer_token_embd, inp_gate, proj), "
+                   + "per-layer FFN widths (feed_forward_length is an array), "
+                   + "KV sharing across layers (attention.shared_kv_layers), and "
+                   + "per-layer output scaling",
+        // Same family under the name llama.cpp uses for the 3n conversions.
+        ["gemma3n"] = "per-layer input embeddings, per-layer FFN widths and shared KV layers "
+                    + "(same architecture family as gemma4)",
+    };
+
+    /// <summary>
+    /// Fails a model whose architecture is known not to work, before anything is
+    /// allocated, so the message names the architecture instead of a tensor size.
+    /// </summary>
+    private static void ThrowIfArchitectureUnsupported(string? architecture)
+    {
+        if (string.IsNullOrWhiteSpace(architecture)) return;
+        if (!UnsupportedArchitectures.TryGetValue(architecture, out string? reason)) return;
+
+        throw new NotSupportedException(
+            $"Model architecture '{architecture}' is not supported. It uses {reason}, " +
+            "none of which the decoder implements. The file is fine — SharpMind cannot run it. " +
+            "Loading it anyway would derive the wrong layer shapes and produce garbage.");
+    }
 
     /// <summary>
     /// Per-block tensors for inference: norms and biases only. The 2D weights are

--- a/SharpMind.Model/Transformer.cs
+++ b/SharpMind.Model/Transformer.cs
@@ -462,6 +462,55 @@ public sealed class Transformer : IDisposable
         return result;
     }
 
+    /// <summary>
+    /// Prefill for a prompt of any length: same result as
+    /// <see cref="ForwardLastLogits"/> over the whole prompt, but split into
+    /// passes the workspace can actually hold.
+    ///
+    /// The workspace is a bump allocator sized for
+    /// <see cref="Core.Memory.Workspace.MaxPrefillTokens"/> tokens per pass —
+    /// sizing it for a whole context window would need tens of gigabytes — so
+    /// a one-shot prefill of a real chat prompt (a system prompt with tool
+    /// definitions is already well over a thousand tokens) overruns it and
+    /// throws OutOfMemoryException partway through the first turn.
+    ///
+    /// Every chunk but the last exists only to extend the KV cache; their
+    /// logits are discarded, and the workspace is rewound between them. The
+    /// returned tensor is the caller's, exactly as with ForwardLastLogits.
+    /// </summary>
+    public Tensor<float> PrefillLastLogits(int[] promptIds, IKVCache[] caches, int positionOffset = 0, Core.Memory.Workspace? workspace = null)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(promptIds);
+        if (promptIds.Length == 0)
+            throw new ArgumentException("Prompt has no token IDs; cannot prefill.", nameof(promptIds));
+
+        int chunkLen = Core.Memory.Workspace.MaxPrefillTokens;
+
+        // Without a workspace every tensor is heap-allocated, so there is no
+        // capacity to overrun and nothing to gain from chunking.
+        if (workspace is null || promptIds.Length <= chunkLen)
+        {
+            using var whole = Tensor<int>.From(promptIds, 1, promptIds.Length);
+            return ForwardLastLogits(whole, caches, positionOffset, workspace);
+        }
+
+        Tensor<float>? logits = null;
+        for (int start = 0; start < promptIds.Length; start += chunkLen)
+        {
+            int len = Math.Min(chunkLen, promptIds.Length - start);
+
+            // The previous chunk's logits live in the workspace being rewound.
+            logits?.Dispose();
+            workspace.Reset();
+
+            using var input = workspace.Rent<int>([1, len]);
+            promptIds.AsSpan(start, len).CopyTo(input.Data);
+            logits = ForwardLastLogits(input, caches, positionOffset + start, workspace);
+        }
+        return logits!;
+    }
+
     private void DisposeCache()
     {
         // _cachedHidden may alias _cachedEmbedding (blocks return input tensor in-place).

--- a/SharpMind.Model/TransformerWeights.cs
+++ b/SharpMind.Model/TransformerWeights.cs
@@ -87,7 +87,12 @@ public abstract class TransformerWeights : IDisposable
 
     public (Tensor<float>? target, BlockWeights? block, string? rawField) ResolveTarget(string name)
     {
-        if (name.Contains("token_embd", StringComparison.OrdinalIgnoreCase)) return (EmbeddingWeight, null, null);
+        // "per_layer_token_embd" (gemma-3n/gemma-4) also contains "token_embd" but is a
+        // separate per-layer table, not the token embedding — routing it here fed a
+        // [8960, 262144] tensor into EmbeddingWeight.
+        if (name.Contains("token_embd", StringComparison.OrdinalIgnoreCase)
+            && !name.Contains("per_layer", StringComparison.OrdinalIgnoreCase))
+            return (EmbeddingWeight, null, null);
         if (name.Contains("position_embd", StringComparison.OrdinalIgnoreCase)) return (PositionEmbedding, null, null);
         if (name.Contains("output_norm", StringComparison.OrdinalIgnoreCase))
         {

--- a/SharpMind.Tests/Core/RoPEConventionTests.cs
+++ b/SharpMind.Tests/Core/RoPEConventionTests.cs
@@ -1,0 +1,112 @@
+using SharpMind.Core.Embeddings;
+using SharpMind.Core.Tensors;
+using SharpMind.Model.Layers.Attention;
+using Xunit;
+
+namespace SharpMind.Tests.Core;
+
+/// <summary>
+/// RoPE has two incompatible pairing conventions and the right one depends on
+/// the model architecture:
+///
+///   adjacent ("NORM", GPT-J/ggml): rotates (2i, 2i+1)
+///   NeoX     (HF "rotate_half"):   rotates (d, d + ropeDim/2)
+///
+/// llama.cpp fixes this per architecture rather than storing it in the GGUF.
+/// LLaMA-family files are converted with Q/K permuted so adjacent pairing
+/// reproduces rotate_half; Qwen/Gemma/Phi/StableLM are not permuted and need
+/// true NeoX. Applying adjacent pairing to a Qwen2 model leaves it locally
+/// fluent but unable to use position — it repeats and cannot recall facts
+/// ("The capital of France is" -> " a city in the north of the of the of").
+/// </summary>
+public sealed class RoPEConventionTests
+{
+    private const int HeadDim = 4;
+    private const float Theta = 10_000f;
+
+    // freqs[i] = theta^(-2i/headDim)  ->  [1.0, 0.01] for headDim 4
+    private static readonly float Freq0 = 1f;
+    private static readonly float Freq1 = 1f / MathF.Pow(Theta, 2f * 1 / HeadDim);
+
+    /// <summary>[SeqLen=1, NumHeads=1, HeadDim=4] holding 1,2,3,4.</summary>
+    private static Tensor<float> Input() => Tensor<float>.From([1f, 2f, 3f, 4f], 1, 1, HeadDim);
+
+    [Fact]
+    public void Adjacent_RotatesPairs_2i_2iPlus1()
+    {
+        var rope = new RoPE(HeadDim, maxSeqLen: 8, Theta, neoxStyle: false);
+        using var x = Input();
+
+        rope.Apply(x, positionOffset: 1);
+
+        float c0 = MathF.Cos(Freq0), s0 = MathF.Sin(Freq0);
+        float c1 = MathF.Cos(Freq1), s1 = MathF.Sin(Freq1);
+
+        Assert.Equal(1f * c0 - 2f * s0, x.Data[0], precision: 4);
+        Assert.Equal(2f * c0 + 1f * s0, x.Data[1], precision: 4);
+        Assert.Equal(3f * c1 - 4f * s1, x.Data[2], precision: 4);
+        Assert.Equal(4f * c1 + 3f * s1, x.Data[3], precision: 4);
+    }
+
+    [Fact]
+    public void Neox_RotatesPairs_d_dPlusHalf()
+    {
+        var rope = new RoPE(HeadDim, maxSeqLen: 8, Theta, neoxStyle: true);
+        using var x = Input();
+
+        rope.Apply(x, positionOffset: 1);
+
+        float c0 = MathF.Cos(Freq0), s0 = MathF.Sin(Freq0);
+        float c1 = MathF.Cos(Freq1), s1 = MathF.Sin(Freq1);
+
+        // pairs are (0,2) and (1,3)
+        Assert.Equal(1f * c0 - 3f * s0, x.Data[0], precision: 4);
+        Assert.Equal(2f * c1 - 4f * s1, x.Data[1], precision: 4);
+        Assert.Equal(3f * c0 + 1f * s0, x.Data[2], precision: 4);
+        Assert.Equal(4f * c1 + 2f * s1, x.Data[3], precision: 4);
+    }
+
+    [Fact]
+    public void Conventions_Differ_AtNonZeroPositions()
+    {
+        var adjacent = new RoPE(HeadDim, maxSeqLen: 8, Theta, neoxStyle: false);
+        var neox = new RoPE(HeadDim, maxSeqLen: 8, Theta, neoxStyle: true);
+        using var a = Input();
+        using var n = Input();
+
+        adjacent.Apply(a, positionOffset: 1);
+        neox.Apply(n, positionOffset: 1);
+
+        Assert.NotEqual(a.Data[0], n.Data[0], precision: 3);
+    }
+
+    [Fact]
+    public void Position0_IsIdentity_ForBothConventions()
+    {
+        foreach (bool neox in new[] { false, true })
+        {
+            var rope = new RoPE(HeadDim, maxSeqLen: 8, Theta, neoxStyle: neox);
+            using var x = Input();
+
+            rope.Apply(x, positionOffset: 0);
+
+            Assert.Equal(1f, x.Data[0], precision: 5);
+            Assert.Equal(2f, x.Data[1], precision: 5);
+            Assert.Equal(3f, x.Data[2], precision: 5);
+            Assert.Equal(4f, x.Data[3], precision: 5);
+        }
+    }
+
+    [Theory]
+    [InlineData("qwen2", true)]
+    [InlineData("qwen3", true)]
+    [InlineData("gemma2", true)]
+    [InlineData("phi3", true)]
+    [InlineData("stablelm", true)]
+    [InlineData("llama", false)]
+    [InlineData("baichuan", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void ArchitectureSelectsConvention(string? architecture, bool expected)
+        => Assert.Equal(expected, AttentionLayer.UsesNeoxRope(architecture));
+}

--- a/SharpMind.Tests/Core/RoPEConventionTests.cs
+++ b/SharpMind.Tests/Core/RoPEConventionTests.cs
@@ -97,6 +97,30 @@ public sealed class RoPEConventionTests
         }
     }
 
+    /// <summary>
+    /// The cos/sin tables are shared through a static cache. It used to be keyed
+    /// by HashCode.Combine of the config, so a 32-bit collision would hand a model
+    /// another configuration's rotary tables. Distinct configs must stay distinct.
+    /// </summary>
+    [Fact]
+    public void DifferentConfigs_DoNotShareCachedTables()
+    {
+        using var a = Input();
+        using var b = Input();
+        using var c = Input();
+
+        new RoPE(HeadDim, maxSeqLen: 8, theta: 10_000f).Apply(a, positionOffset: 1);
+        new RoPE(HeadDim, maxSeqLen: 8, theta: 500_000f).Apply(b, positionOffset: 1);
+        // Same theta as the first, so it must reproduce the first result exactly.
+        new RoPE(HeadDim, maxSeqLen: 8, theta: 10_000f).Apply(c, positionOffset: 1);
+
+        // Pair 0 rotates at freq theta^0 == 1 for every theta, so only pair 1
+        // (indices 2 and 3) distinguishes the two configurations.
+        Assert.NotEqual(a.Data[2], b.Data[2], precision: 4);
+        Assert.Equal(a.Data[2], c.Data[2], precision: 6);
+        Assert.Equal(a.Data[3], c.Data[3], precision: 6);
+    }
+
     [Theory]
     [InlineData("qwen2", true)]
     [InlineData("qwen3", true)]

--- a/SharpMind.Tests/Model/ChunkedPrefillTests.cs
+++ b/SharpMind.Tests/Model/ChunkedPrefillTests.cs
@@ -1,0 +1,102 @@
+using SharpMind.Core;
+using SharpMind.Core.Memory;
+using SharpMind.Core.Tensors;
+using SharpMind.Model;
+using SharpMind.Model.Config;
+using SharpMind.Training;
+using Xunit;
+
+namespace SharpMind.Tests.Model;
+
+/// <summary>
+/// The workspace is a bump allocator sized for Workspace.MaxPrefillTokens
+/// tokens per forward pass, but every generator used to prefill the whole
+/// prompt in one pass. Any prompt longer than that — i.e. every real chat
+/// prompt, since the agent system prompt alone runs well over a thousand
+/// tokens — died with "Workspace capacity exceeded" partway through the
+/// first turn, which the CUI then swallowed into a silent "Thinking..."
+/// forever.
+/// </summary>
+public sealed class ChunkedPrefillTests
+{
+    private static ModelConfig Cfg => new()
+    {
+        VocabSize = 128,
+        HiddenDim = 32,
+        NumLayers = 2,
+        NumHeads = 4,
+        NumKvHeads = 2,
+        FfnDim = 64,
+        MaxSeqLen = 1024,
+    };
+
+    private static Transformer BuildModel()
+    {
+        var sharpConfig = SharpMindConfig.Gpt with { Hardware = HardwareTier.Scalar };
+        var weights = ModelFactory.CreateForTraining(Cfg, sharpConfig);
+        WeightInitializer.InitializeRandomly(weights, 1234);
+        return ModelFactory.CreateTrainingTransformer(weights, sharpConfig);
+    }
+
+    private static IKVCache[] BuildCaches() =>
+        [.. Enumerable.Range(0, Cfg.NumLayers)
+            .Select(_ => (IKVCache)new KVCache(1, Cfg.NumKvHeads, Cfg.MaxSeqLen, Cfg.HeadDim))];
+
+    private static int[] BuildPrompt(int length)
+    {
+        var rng = new Random(7);
+        return [.. Enumerable.Range(0, length).Select(_ => rng.Next(Cfg.VocabSize))];
+    }
+
+    [Fact]
+    public void PrefillLastLogits_MatchesOneShotForward_WhenPromptExceedsChunkSize()
+    {
+        int promptLen = Workspace.MaxPrefillTokens * 2 + 37; // spans several chunks, ragged last one
+        int[] promptIds = BuildPrompt(promptLen);
+
+        using var model = BuildModel();
+
+        // Reference: one pass over the whole prompt with no workspace at all,
+        // so nothing is chunked and nothing can run out of capacity.
+        var refCaches = BuildCaches();
+        using var wholeInput = Tensor<int>.From(promptIds, 1, promptLen);
+        using var expected = model.ForwardLastLogits(wholeInput, refCaches, 0, null);
+
+        // Actual: chunked, against a workspace sized the way the generators size it.
+        var caches = BuildCaches();
+        using var workspace = new Workspace(
+            Workspace.CalculateRequiredSize(Cfg.HiddenDim, Cfg.FfnDim, Cfg.VocabSize, Cfg.NumLayers, Cfg.MaxSeqLen));
+        using var actual = model.PrefillLastLogits(promptIds, caches, 0, workspace);
+
+        Assert.Equal(expected.Shape[^1], actual.Shape[^1]);
+        for (int i = 0; i < Cfg.VocabSize; i++)
+            Assert.True(MathF.Abs(expected.Data[i] - actual.Data[i]) < 1e-3f,
+                $"logit[{i}] chunked={actual.Data[i]} one-shot={expected.Data[i]}");
+
+        // The KV cache must end up holding the whole prompt, not just the last chunk.
+        Assert.Equal(promptLen, caches[0].Length);
+
+        foreach (var c in refCaches) c.Dispose();
+        foreach (var c in caches) c.Dispose();
+    }
+
+    [Fact]
+    public void PrefillLastLogits_HonoursPositionOffset_ForASecondTurn()
+    {
+        int[] first = BuildPrompt(Workspace.MaxPrefillTokens + 10);
+        int[] second = BuildPrompt(Workspace.MaxPrefillTokens + 5);
+
+        using var model = BuildModel();
+        var caches = BuildCaches();
+        using var workspace = new Workspace(
+            Workspace.CalculateRequiredSize(Cfg.HiddenDim, Cfg.FfnDim, Cfg.VocabSize, Cfg.NumLayers, Cfg.MaxSeqLen));
+
+        using (var _ = model.PrefillLastLogits(first, caches, 0, workspace)) { }
+        Assert.Equal(first.Length, caches[0].Length);
+
+        using (var _ = model.PrefillLastLogits(second, caches, caches[0].Length, workspace)) { }
+        Assert.Equal(first.Length + second.Length, caches[0].Length);
+
+        foreach (var c in caches) c.Dispose();
+    }
+}

--- a/SharpMind.Tests/ModelFormat/UnsupportedArchitectureTests.cs
+++ b/SharpMind.Tests/ModelFormat/UnsupportedArchitectureTests.cs
@@ -1,0 +1,65 @@
+using SharpMind.Core;
+using SharpMind.Core.Quantization;
+using SharpMind.Model;
+using SharpMind.Model.Config;
+using Xunit;
+
+namespace SharpMind.Tests.ModelFormat;
+
+/// <summary>
+/// A model whose architecture the decoder does not implement must say so, before
+/// anything is allocated.
+///
+/// gemma-4 (gemma-3n family) used to derive layer shapes from its config, disagree
+/// with its own tensors, and surface as a byte-count mismatch at the first matmul —
+/// which reads as a corrupt file rather than an unsupported architecture. Its
+/// attn_q is [1536, 2048] while head_count 8 x key_length 512 implies 4096.
+/// </summary>
+public sealed class UnsupportedArchitectureTests
+{
+    private static ModelConfig Cfg(string architecture) => new()
+    {
+        Architecture = architecture,
+        VocabSize = 128,
+        HiddenDim = 16,
+        NumLayers = 2,
+        NumHeads = 2,
+        NumKvHeads = 2,
+        FfnDim = 32,
+        MaxSeqLen = 32,
+    };
+
+    private static Exception? Load(string architecture)
+    {
+        var sharpConfig = SharpMindConfig.Gpt with { Hardware = HardwareTier.Scalar };
+        var qOps = QuantizationFactory.Create(HardwareTier.Scalar);
+        return Record.Exception(() => ModelFactory.CreateWeights(
+            Cfg(architecture), sharpConfig, qOps, "does-not-exist.gguf"));
+    }
+
+    [Theory]
+    [InlineData("gemma4")]
+    [InlineData("GEMMA4")]
+    [InlineData("gemma3n")]
+    public void UnsupportedArchitecture_FailsWithItsName(string architecture)
+    {
+        var ex = Assert.IsType<NotSupportedException>(Load(architecture));
+
+        Assert.Contains(architecture, ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("not supported", ex.Message, StringComparison.OrdinalIgnoreCase);
+        // Names why, so nobody re-derives it from a tensor size.
+        Assert.Contains("per-layer", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The gate is a denylist, so an architecture that is not on it must get past
+    /// this check — here it goes on to fail on the missing file instead.
+    /// </summary>
+    [Theory]
+    [InlineData("qwen2")]
+    [InlineData("llama")]
+    [InlineData("gemma2")]
+    [InlineData("")]
+    public void OtherArchitectures_AreNotBlocked(string architecture)
+        => Assert.IsNotType<NotSupportedException>(Load(architecture));
+}

--- a/SharpMind.Tests/Tokenization/BpeMergeCompletenessTests.cs
+++ b/SharpMind.Tests/Tokenization/BpeMergeCompletenessTests.cs
@@ -1,0 +1,83 @@
+using SharpMind.Tokenization;
+using SharpMind.Tokenization.Vocab;
+using Xunit;
+
+namespace SharpMind.Tests.Tokenization;
+
+/// <summary>
+/// BPE must apply every merge the vocabulary supports, not only those adjacent
+/// to the last merge point.
+///
+/// The merge loop used to hold a priority queue of *positions* into a list it
+/// mutated with RemoveAt. A merge shifted every later element down one, so a
+/// queued position further right then referred to the wrong pair, failed
+/// revalidation, and was discarded. Only positions idx-1/idx/idx+1 were
+/// re-queued, so a pending merge separated from the merge point by
+/// unmergeable tokens was lost for good.
+///
+/// Against a real Qwen2 vocabulary that shredded 9 of 20 common words
+/// (" helpful" -> "Ġhelp|fu|l", " assistant" -> "Ġass|is|ta|nt") while
+/// decode(encode(x)) still round-tripped, which is why it went unnoticed.
+/// </summary>
+public sealed class BpeMergeCompletenessTests
+{
+    /// <summary>UNK/BOS/EOS, the 256 GPT-2 byte tokens, then the merge results.</summary>
+    private static Tokenizer BuildTokenizer(string[] extraTokens, string[] merges)
+    {
+        var tokens = new List<string> { "[UNK]", "[BOS]", "[EOS]" };
+        for (int b = 0; b < 256; b++) tokens.Add(Vocabulary.ByteTokenString(b));
+        tokens.AddRange(extraTokens);
+        return Tokenizer.FromGguf([.. tokens], merges, tokenTypes: null, bosId: 1, eosId: 2);
+    }
+
+    /// <summary>
+    /// "abzzzef": (a,b) merges at the far left and (e,f) at the far right, with
+    /// three unmergeable tokens between them so no merge is ever adjacent to
+    /// the (e,f) pair. Merging (a,b) shifts (e,f) left by one; the old code
+    /// dropped its stale queue entry and never revisited it, emitting
+    /// "ab|z|z|z|e|f" instead of "ab|z|z|z|ef".
+    /// </summary>
+    [Fact]
+    public void MergeSeparatedFromMergePoint_IsNotDropped()
+    {
+        var tok = BuildTokenizer(["ab", "ef"], ["a b", "e f"]);
+
+        int[] ids = tok.Encode("abzzzef", addBos: false, addEos: false);
+
+        Assert.Equal(["ab", "z", "z", "z", "ef"], ids.Select(tok.IdToToken).ToArray());
+    }
+
+    /// <summary>Same shape, with the distant merge outranking the near one.</summary>
+    [Fact]
+    public void DistantMerge_SurvivesRegardlessOfRankOrder()
+    {
+        var tok = BuildTokenizer(["ab", "ef"], ["e f", "a b"]);
+
+        int[] ids = tok.Encode("abzzzef", addBos: false, addEos: false);
+
+        Assert.Equal(["ab", "z", "z", "z", "ef"], ids.Select(tok.IdToToken).ToArray());
+    }
+
+    /// <summary>A full merge chain still collapses to the single largest token.</summary>
+    [Fact]
+    public void FullMergeChain_CollapsesToOneToken()
+    {
+        var tok = BuildTokenizer(
+            ["ab", "cd", "ef", "gh", "abcd", "efgh", "abcdefgh"],
+            ["g h", "a b", "e f", "c d", "ab cd", "ef gh", "abcd efgh"]);
+
+        int[] ids = tok.Encode("abcdefgh", addBos: false, addEos: false);
+
+        Assert.Single(ids);
+        Assert.Equal("abcdefgh", tok.IdToToken(ids[0]));
+    }
+
+    [Fact]
+    public void Encode_RoundTripsAfterMerging()
+    {
+        var tok = BuildTokenizer(["ab", "ef"], ["a b", "e f"]);
+
+        foreach (string text in new[] { "abzzzef", "ab", "ef", "zzz" })
+            Assert.Equal(text, tok.Decode(tok.Encode(text, addBos: false, addEos: false)));
+    }
+}

--- a/SharpMind.Tokenization/Bpe/BpeEncoder.cs
+++ b/SharpMind.Tokenization/Bpe/BpeEncoder.cs
@@ -304,48 +304,59 @@ public sealed class BpeEncoder
     /// </summary>
     private void ApplyMerges(List<string> tokens)
     {
-        if (tokens.Count <= 1) return;
+        int n = tokens.Count;
+        if (n <= 1) return;
 
-        // Seed: evaluate all initial adjacent pairs.
-        var queue = new PriorityQueue<int, int>(); // (pairIndex, rank)
-        for (int i = 0; i < tokens.Count - 1; i++)
+        // Slot indices stay stable for the whole merge: a List.RemoveAt would
+        // shift every later element down one, so every queued index to the right
+        // of a merge silently pointed at the wrong pair, failed revalidation and
+        // was dropped. Those merges were then never retried — " helpful" came out
+        // as "Ġhelp|fu|l" even though "Ġhelpful" is in the vocab.
+        var parts = new string[n];
+        tokens.CopyTo(parts);
+        var next = new int[n];
+        var prev = new int[n];
+        var alive = new bool[n];
+        for (int i = 0; i < n; i++)
         {
-            if (_mergeIndex.TryGetValue((tokens[i], tokens[i + 1]), out var entry))
-                queue.Enqueue(i, entry.Rank);
+            next[i] = i + 1 < n ? i + 1 : -1;
+            prev[i] = i - 1;
+            alive[i] = true;
         }
 
-        while (queue.TryDequeue(out int idx, out int rank))
+        var queue = new PriorityQueue<int, int>(); // (left slot, rank)
+        for (int i = 0; i + 1 < n; i++)
         {
-            // --- Lazy-deletion guard ---
-            // The pair at `idx` may have been invalidated by a prior merge.
-            // Re-validate by checking that both halves still match.
-            if (idx >= tokens.Count - 1) continue;
-            if (!_mergeIndex.TryGetValue((tokens[idx], tokens[idx + 1]), out var entry)) continue;
-            if (entry.Rank != rank) continue; // stale — a higher-priority merge replaced one of these tokens
-
-            // --- Merge the pair at idx and idx+1 ---
-            tokens[idx] = entry.Merged;
-            tokens.RemoveAt(idx + 1);
-
-            // Re-evaluate the pair to the LEFT of the merged token (idx-1, idx).
-            if (idx > 0)
-                EnqueueSinglePair(queue, tokens, idx - 1);
-
-            // Re-evaluate the pair to the RIGHT of the merged token (idx, idx+1).
-            if (idx < tokens.Count - 1)
-                EnqueueSinglePair(queue, tokens, idx);
-
-            // Re-evaluate the pair that SHIFTED into position idx+1 (was at idx+2 before RemoveAt).
-            if (idx + 1 < tokens.Count - 1)
-                EnqueueSinglePair(queue, tokens, idx + 1);
+            if (_mergeIndex.TryGetValue((parts[i], parts[i + 1]), out var seed))
+                queue.Enqueue(i, seed.Rank);
         }
-    }
 
-    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-    private void EnqueueSinglePair(PriorityQueue<int, int> queue, List<string> tokens, int idx)
-    {
-        if (_mergeIndex.TryGetValue((tokens[idx], tokens[idx + 1]), out var entry))
-            queue.Enqueue(idx, entry.Rank);
+        while (queue.TryDequeue(out int left, out int rank))
+        {
+            if (!alive[left]) continue;
+            int right = next[left];
+            if (right < 0 || !alive[right]) continue;
+            if (!_mergeIndex.TryGetValue((parts[left], parts[right]), out var entry)) continue;
+            if (entry.Rank != rank) continue; // stale: this slot's pair changed since enqueue
+
+            parts[left] = entry.Merged;
+            alive[right] = false;
+
+            int after = next[right];
+            next[left] = after;
+            if (after >= 0) prev[after] = left;
+
+            int before = prev[left];
+            if (before >= 0 && _mergeIndex.TryGetValue((parts[before], parts[left]), out var leftPair))
+                queue.Enqueue(before, leftPair.Rank);
+            if (after >= 0 && _mergeIndex.TryGetValue((parts[left], parts[after]), out var rightPair))
+                queue.Enqueue(left, rightPair.Rank);
+        }
+
+        // Slot 0 is never removed (only the right half of a pair is), so the
+        // surviving chain always starts there.
+        tokens.Clear();
+        for (int i = 0; i >= 0; i = next[i]) tokens.Add(parts[i]);
     }
 
     private void EncodeSentencePieceSegment(string text, bool isFirstSegment, List<int> ids)
@@ -399,30 +410,57 @@ public sealed class BpeEncoder
     {
         if (tokens.Count <= 1) return;
 
+        // Same stable-slot scheme as ApplyMerges: RemoveAt shifted positions out
+        // from under queued indices, dropping merges (and here, with no score
+        // revalidation, a shifted index could merge a pair that was never queued).
+        int n = tokens.Count;
+        var parts = new string[n];
+        for (int i = 0; i < n; i++) parts[i] = tokens[i].ToString();
+        var next = new int[n];
+        var prev = new int[n];
+        var alive = new bool[n];
+        for (int i = 0; i < n; i++)
+        {
+            next[i] = i + 1 < n ? i + 1 : -1;
+            prev[i] = i - 1;
+            alive[i] = true;
+        }
+
         var queue = new PriorityQueue<int, float>();
 
-        void TryEnqueue(int idx)
+        void TryEnqueue(int left)
         {
-            if (idx < 0 || idx >= tokens.Count - 1) return;
-            string merged = tokens[idx].ToString() + tokens[idx + 1].ToString();
-            if (_vocab.TryGetId(merged, out int id))
-                queue.Enqueue(idx, -ScoreOf(id));
+            if (left < 0 || !alive[left]) return;
+            int right = next[left];
+            if (right < 0 || !alive[right]) return;
+            if (_vocab.TryGetId(parts[left] + parts[right], out int id))
+                queue.Enqueue(left, -ScoreOf(id));
         }
 
-        for (int i = 0; i < tokens.Count - 1; i++) TryEnqueue(i);
+        for (int i = 0; i < n; i++) TryEnqueue(i);
 
-        while (queue.TryDequeue(out int idx, out _))
+        while (queue.TryDequeue(out int left, out float priority))
         {
-            if (idx >= tokens.Count - 1) continue;
-            string merged = tokens[idx].ToString() + tokens[idx + 1].ToString();
-            if (!_vocab.TryGetId(merged, out _)) continue;
+            if (!alive[left]) continue;
+            int right = next[left];
+            if (right < 0 || !alive[right]) continue;
+            string merged = parts[left] + parts[right];
+            if (!_vocab.TryGetId(merged, out int id)) continue;
+            if (-ScoreOf(id) != priority) continue; // stale: this slot's pair changed
 
-            tokens[idx] = merged.AsMemory();
-            tokens.RemoveAt(idx + 1);
+            parts[left] = merged;
+            alive[right] = false;
 
-            if (idx > 0) TryEnqueue(idx - 1);
-            if (idx < tokens.Count - 1) TryEnqueue(idx);
+            int after = next[right];
+            next[left] = after;
+            if (after >= 0) prev[after] = left;
+
+            TryEnqueue(prev[left]);
+            TryEnqueue(left);
         }
+
+        tokens.Clear();
+        for (int i = 0; i >= 0; i = next[i]) tokens.Add(parts[i].AsMemory());
     }
 
     private float ScoreOf(int id) => _scores != null && id >= 0 && id < _scores.Count ? _scores[id] : 0f;


### PR DESCRIPTION
Five commits on the model loading and prefill path. **Stacks on #4** (the RoPE cache-key change builds on its `neoxStyle` flag and test file), so the first four commits here are #4's; the five new ones are the top of the branch. Once #4 merges this shows just those five.

## 1. Quantized-resident loading halves inference memory

`ModelFactory.CreateWeights` allocated an F32 tensor for every attention and FFN weight in `LoadMode.Full`, and `GgufLoader` dequantized into them while also retaining the raw quantized bytes. Both copies stayed resident — 3.57 GB allocated before a byte was read, on a 0.49 GB model.

`CreateTransformer` always builds `InferenceLinearLayer`, whose forward reads `RawQuantizedData` and never touches those floats (`LoadMode.Streaming` has always left them null and produces identical output). So for a chat/inference load the F32 copy is pure overhead.

`CreateWeights` takes `quantizedResident` (default `false`) which allocates the same lean per-block set streaming already used — norms and biases only. Measured on qwen2-0.5b-instruct, 6 greedy tokens:

```
q8_0     4.97 GB -> 2.48 GB
q4_k_m   4.92 GB -> 2.43 GB
fp16     5.87 GB -> 3.38 GB
```

Generated token ids are identical in every pair. It is opt-in because reading weights back as floats after a load is a real use (the GGUF→SMM round trip and training-export parity tests compare reloaded float tensors); `SessionLauncher` opts in for the chat path. Training is untouched.

## 2. RoPE table cache keyed by config, not by a hash of it

`RoPE` shares its cos/sin tables through a static cache keyed by `HashCode.Combine(theta, halfDim, maxSeqLen, scaling…)`. A hash is 32 bits and collides silently: two rotary configurations map to the same slot and the second model gets the first one's tables — the model simply uses wrong positions. `HashCode.Combine` is also seeded per process, so which pairs collide changes between runs, which fits a `RoPETests` failure seen once in a full suite run and never in isolation.

Key is now a `readonly record struct` of the values themselves. `neoxStyle` is deliberately not part of it (it changes how tables are applied, not their contents); `_ropeDim` is stored rather than `halfDim` so an odd ropeDim cannot alias an even one through integer division. Test asserts two thetas produce different rotations while a repeat of the first reproduces it exactly.

## 3. Reject mismatched weight shapes at load, not at the first matmul

`InferenceLinearLayer` checked `RawQuantizedData`'s size against the layer's dimensions inside `Forward`. A model whose tensors don't match the config-derived shapes therefore appeared to load and then threw mid-generation, which reads as a runtime bug rather than an unsupported architecture. The check moved into `SetRawWeight` so it fires while the model is built, and says what it means:

```
[q_proj] weight shape does not match this architecture: dtype=Q4_K,
K=1536, N=4096 expects 3538944 bytes but the model provides 1769472.
The file's tensor is 1/2 of the expected size, so the layer dimensions
derived from the model config are wrong for this architecture.
```

`Forward` keeps its own guard as defence in depth — that's what stops a kernel writing past the buffer.

## 4. Reject architectures the decoder cannot run, by name

gemma-4 (gemma-3n family) got as far as a forward pass before failing. Correcting `head_dim` alone would be worse: the model would clear the shape guard and generate garbage silently, because the file departs from the generic decoder in several places at once:

```
gemma4.attention.head_count = 8, key_length = 512  -> qDim 4096
blk.0.attn_q.weight  shape [1536, 2048]            -> really 8 x 256
feed_forward_length          = int[]   per-layer FFN widths
attention.shared_kv_layers   = 20      KV reused across layers
embedding_length_per_layer_input = 256 per-layer input embeddings
blk.0.{inp_gate,proj,layer_output_scale,post_norm}.weight
```

So `CreateWeights` gates on the architecture name before anything is allocated. Deliberately a **denylist** — only architectures actually observed to fail are listed, so this can never reject a model that would have loaded. Metadata reading is untouched, so a model browser can still list and inspect these files. Both gemma-4-E2B and gemma-4-e4b now fail at load with a message that says the file is fine and SharpMind cannot run it; qwen2-0.5b still loads and generates.

## 5. Prefill long prompts in chunks the workspace can hold

Every chat turn in the CUI died on its first forward with "Workspace capacity exceeded", and nothing showed it: `ChatSession` puts the reason on the stream entry, `ChatView` dropped that field, and `ChatSessionBridge.Faulted` was set but read by nobody. The screen sat on "Thinking…".

Two causes:

- `Workspace.CalculateRequiredSize` sizes for 128 prefill tokens and its comment claimed "the prefill path for long prompts is handled by the generator" — no generator did. Standard, Speculative and Medusa all fed the whole prompt to one `ForwardLastLogits`; an agent system prompt with tool definitions is already ~1700 tokens. `Transformer.PrefillLastLogits` now splits the pass into `Workspace.MaxPrefillTokens` chunks, discarding all but the last chunk's logits, and all three generators prefill through it.
- The estimate was short even for a 128-token chunk: `InferenceLinearLayer` materialised the bias broadcast into a second full `[tokens, OutFeatures]` tensor, which for the fused gate/up projection is the largest allocation in a layer. Bias is now added row-wise in place, which also removes a leaked broadcast tensor in `TrainingLinearLayer.ForwardWithState`. Peak workspace use for a 128-token chunk of qwen2-0.5B drops from over capacity to 238 MB of 376 MB.

`ChatView` now surfaces `entry.Error` and a faulted bridge. Verified end to end against qwen2-0_5b-instruct-fp16.gguf through the CUI's own launch path: a 1691-token prompt completes and returns a real response.

## Verification

- Suite 675/675 on this branch as rebased onto current `master` + #4.
- Each commit's message carries its own measurements; qwen2-0.5b-instruct output ids unchanged throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
