### PR TITLE
Stop allocating a dead full-F32 weight per quantized inference layer

### DIFF
--- a/SharpMind.Model/Layers/InferenceLinearLayer.cs
+++ b/SharpMind.Model/Layers/InferenceLinearLayer.cs
@@ -14,7 +14,10 @@ public abstract class InferenceLinearLayer : LinearLayer
     public readonly QuantDType QuantDtype;
 
     protected InferenceLinearLayer(string name, int inFeatures, int outFeatures, bool bias, Tensor<float>? weight, Tensor<float>? biasTensor, QuantDType quantDType)
-        : base(name, inFeatures, outFeatures, bias, weight, biasTensor)
+        // Forward reads RawQuantizedData, never the float weight, so a null weight
+        // (quantized-resident loading) must not materialise a full F32 copy —
+        // that second copy is what put a 7B out of reach and OOM'd a 14B at load.
+        : base(name, inFeatures, outFeatures, bias, weight, biasTensor, allocateFullWeight: false)
     {
         QuantDtype = quantDType;
     }

--- a/SharpMind.Model/Layers/Linearlayer.cs
+++ b/SharpMind.Model/Layers/Linearlayer.cs
@@ -13,14 +13,22 @@ public abstract class LinearLayer : IDisposable
     protected bool _ownsBias;
     private bool _disposed;
 
-    protected LinearLayer(string name, int inFeatures, int outFeatures, bool bias, Tensor<float>? weight, Tensor<float>? biasTensor)
+    /// <param name="allocateFullWeight">
+    /// When <paramref name="weight"/> is null, whether to materialise a full
+    /// <c>[inFeatures, outFeatures]</c> float weight (true, the training default)
+    /// or only a one-column placeholder (false). Quantized inference layers run
+    /// off raw bytes and never read this float weight, so on a large model the
+    /// full copy is pure dead memory — ~28 GB on a 7B — and passing false here is
+    /// what lets quantized-resident loading actually stay resident.
+    /// </param>
+    protected LinearLayer(string name, int inFeatures, int outFeatures, bool bias, Tensor<float>? weight, Tensor<float>? biasTensor, bool allocateFullWeight = true)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(inFeatures);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(outFeatures);
         Name = name;
         InFeatures = inFeatures;
         OutFeatures = outFeatures;
-        _weight = weight ?? new Tensor<float>(inFeatures, outFeatures);
+        _weight = weight ?? new Tensor<float>(inFeatures, allocateFullWeight ? outFeatures : 1);
         _bias = biasTensor ?? (bias ? new Tensor<float>(outFeatures) : null);
         _ownsWeight = weight == null;
         _ownsBias = biasTensor == null && _bias != null;

--- a/SharpMind.Tests/Model/QuantizedResidentWeightTests.cs
+++ b/SharpMind.Tests/Model/QuantizedResidentWeightTests.cs
@@ -1,0 +1,43 @@
+using SharpMind.Core;
+using SharpMind.Core.Quantization;
+using SharpMind.Model.Config;
+using SharpMind.Model.Layers;
+using Xunit;
+
+namespace SharpMind.Tests.Model;
+
+/// <summary>
+/// An InferenceLinearLayer runs the quantized forward off RawQuantizedData and
+/// never reads its float _weight. In quantized-resident loading the caller
+/// passes weight: null, and the base LinearLayer constructor used to fill that
+/// null with a full [inFeatures, outFeatures] F32 tensor — a second dead copy
+/// of every weight, on top of the quantized bytes. Tolerable on a 0.5B model,
+/// but ~28 GB on a 7B and an out-of-memory at load on a 14B, allocated during
+/// CreateTransformer before anything could free it.
+///
+/// A quantized inference layer built without a float weight must hold only a
+/// placeholder, not an in×out tensor.
+/// </summary>
+public sealed class QuantizedResidentWeightTests
+{
+    [Theory]
+    [InlineData(QuantDType.Q8_0)]
+    [InlineData(QuantDType.Q4_K)]
+    public void QuantizedInferenceLayer_WithNullWeight_AllocatesNoFullFloatWeight(QuantDType dtype)
+    {
+        const int inFeatures = 512;
+        const int outFeatures = 4096;   // in×out = 2,097,152 floats if the bug is present
+        var mapping = SharpMindConfig.Gpt.ToJigSawMapping(parallel: false);
+
+        var layer = LinearLayerFactory.Create(
+            "ffn_test", inFeatures, outFeatures, bias: false,
+            weight: null, biasTensor: null, dtype, mapping);
+
+        // The forward reads RawQuantizedData, so the float weight is dead; it must
+        // not be materialised at full size. Anything on the order of one column is
+        // fine (the FreeFloatWeight placeholder is [inFeatures, 1]).
+        Assert.True(layer.Weight.ElementCount <= inFeatures,
+            $"float weight has {layer.Weight.ElementCount} elements; a quantized-resident " +
+            $"layer must not allocate the full {(long)inFeatures * outFeatures}");
+    }
+}


### PR DESCRIPTION
One commit, 14 source lines, no numerics. Quantized-resident loading (#6) was meant to keep only the packed weights in memory, but every quantized inference layer still allocated — and never read — a full F32 copy of its weight. For any model big enough to matter, that allocation is what runs out of memory.

| Qwen2.5-7B-Instruct-Q4_K_M (4.68 GB on disk), 30 GB machine | before | after |
|---|---|---|
| load | `OutOfMemoryException` in `CreateTransformer` (`BuildFfn`) | loads in 28 s, generates coherent tokens through the CUI |

## What was happening

`CreateWeights` in quantized-resident mode allocates lean block weights (norms and biases only; the 2D weights `null`), so the F32 copy no longer sits in `TransformerWeights`. But `CreateTransformer` then builds an `InferenceLinearLayer` per projection passing that `null` weight, and the `LinearLayer` base constructor fills it in:

```csharp
_weight = weight ?? new Tensor<float>(inFeatures, outFeatures);
```

`InferenceLinearLayer.Forward` reads `RawQuantizedData` and never touches that float weight, so it is a second, dead copy of every weight — the very thing `FreeFloatWeight` exists to reclaim, except the allocation itself is what throws. ~2 GB at 0.5B (still loads, which is why it went unnoticed), ~28 GB at 7B, ~56 GB at 14B.

## The change

`LinearLayer`'s constructor takes `allocateFullWeight` (default `true`, unchanged for `TrainingLinearLayer`, which learns real float weights). `InferenceLinearLayer` passes `false`: a `null` weight now yields a one-column `[inFeatures, 1]` placeholder — the same shape `FreeFloatWeight` already reduces it to — instead of the full matrix. When a real float weight *is* supplied (`LoadMode.Full` without quantized-resident), nothing changes.

The GGUF loader is unaffected: it decides whether to dequantize from `weights.ResolveFloatTarget` (the `TransformerWeights` block tensors, `null` in quantized-resident), not from the layer's float weight, and early-returns without writing to it. The raw bytes still reach the layer through `SetRawWeight`. `Forward`, `FreeFloatWeight`, the F32 (non-resident) path and the SMM training exporter are untouched.

## Verification

- `QuantizedResidentWeightTests` builds a quantized inference layer with a `null` weight and asserts its float weight is the placeholder, not the full `in×out` matrix — red before this change (2,097,152 elements), green after.
- 757/757 on this branch off current `master` (ed74547).
- The 7B load above, which could not complete at all before.

Independent of the companion PR (K-quant unpack + KV reuse); either merges alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
