### PR TITLE
Vectorise the K-quant unpack and reuse the KV cache across chat turns for every formatter

### DIFF
--- a/SharpMind.Core/Quantization/QuantizationKernels.Q4.cs
+++ b/SharpMind.Core/Quantization/QuantizationKernels.Q4.cs
@@ -622,6 +622,26 @@ public static partial class QuantizationKernels
         return (float)sum;
     }
 
+    /// <summary>
+    /// Eight consecutive Q4_K nibbles as floats. A 32-value sub-block that starts
+    /// on a 32 boundary lives in one contiguous run of 32 bytes: chunk
+    /// <c>basePos/64</c> of <paramref name="qs"/>, low nibbles for the first 32
+    /// values of the chunk and high nibbles for the next 32. So group
+    /// <paramref name="g"/> of the sub-block is bytes <c>[8g, 8g+8)</c> of that
+    /// run, widened straight from memory (vpmovzxbd) and masked or shifted —
+    /// never decoded one weight at a time into a stack buffer, which cannot
+    /// store-forward into the vector load that follows it.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe Vector256<float> Q4KNibbles8(byte* qs, int basePos, int g)
+    {
+        var v = Avx2.ConvertToVector256Int32(qs + (basePos >> 6) * 32 + g * 8);
+        v = (basePos & 32) == 0
+            ? Avx2.And(v, Vector256.Create(0x0F))
+            : Avx2.ShiftRightLogical(v, 4);   // bytes are < 256, so this is the high nibble
+        return Avx.ConvertToVector256Single(v);
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe float VecDotQ4K_AVX2(float* input, byte* rawWeights, int col, int inFeatures)
     {
@@ -630,7 +650,8 @@ public static partial class QuantizationKernels
         int colBlockStart = col * inFeatures % QK_K;
         int nBlocks = (inFeatures + QK_K - 1) / QK_K;
         double sum = 0;
-        float* vvBuf = stackalloc float[8];
+        var vacc0 = Vector256<float>.Zero;
+        var vacc1 = Vector256<float>.Zero;
         for (int b = 0; b < nBlocks; b++)
         {
             byte* block = rawWeights + (long)(startBlock + b) * BLOCK_BYTES;
@@ -655,19 +676,20 @@ public static partial class QuantizationKernels
 
                     int subRem = Math.Min(32, blockEnd - basePos);
                     int l = 0;
-                    for (; l <= subRem - 8; l += 8)
+                    if ((basePos & 31) == 0)
                     {
-                        for (int sub = 0; sub < 8; sub++)
+                        for (; l <= subRem - 16; l += 16)
                         {
-                            int idx = basePos + l + sub;
-                            int qsByte = (idx / 64) * 32 + (idx % 32);
-                            int qsShift = ((idx % 64) / 32) * 4;
-                            vvBuf[sub] = (qs[qsByte] >> qsShift) & 0x0F;
+                            var vw0 = Avx.Subtract(Avx.Multiply(Q4KNibbles8(qs, basePos, l >> 3), vs), vm);
+                            var vw1 = Avx.Subtract(Avx.Multiply(Q4KNibbles8(qs, basePos, (l >> 3) + 1), vs), vm);
+                            vacc0 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[basePos + l]), vw0), vacc0);
+                            vacc1 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[basePos + l + 8]), vw1), vacc1);
                         }
-                        var vv = Vector256.LoadUnsafe(ref vvBuf[0]);
-                        var vi = Vector256.LoadUnsafe(ref pIn[basePos + l]);
-                        var res = Avx.Multiply(vi, Avx.Subtract(Avx.Multiply(vv, vs), vm));
-                        sum += MathHelpers.HSum256_Avx(res);
+                        for (; l <= subRem - 8; l += 8)
+                        {
+                            var vw = Avx.Subtract(Avx.Multiply(Q4KNibbles8(qs, basePos, l >> 3), vs), vm);
+                            vacc0 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[basePos + l]), vw), vacc0);
+                        }
                     }
                     for (; l < subRem; l++)
                     {
@@ -680,6 +702,7 @@ public static partial class QuantizationKernels
                 }
             }
         }
+        sum += MathHelpers.HSum256_Avx(Avx.Add(vacc0, vacc1));
         return (float)sum;
     }
 
@@ -691,8 +714,8 @@ public static partial class QuantizationKernels
         int colBlockStart = col * inFeatures % QK_K;
         int nBlocks = (inFeatures + QK_K - 1) / QK_K;
         double sum = 0;
-        float* vvBuf = stackalloc float[8];
-        var vacc = Vector256<float>.Zero;
+        var vacc0 = Vector256<float>.Zero;
+        var vacc1 = Vector256<float>.Zero;
         for (int b = 0; b < nBlocks; b++)
         {
             byte* block = rawWeights + (long)(startBlock + b) * BLOCK_BYTES;
@@ -717,19 +740,20 @@ public static partial class QuantizationKernels
 
                     int subRem = Math.Min(32, blockEnd - basePos);
                     int l = 0;
-                    for (; l <= subRem - 8; l += 8)
+                    if ((basePos & 31) == 0)
                     {
-                        for (int sub = 0; sub < 8; sub++)
+                        for (; l <= subRem - 16; l += 16)
                         {
-                            int idx = basePos + l + sub;
-                            int qsByte = (idx / 64) * 32 + (idx % 32);
-                            int qsShift = ((idx % 64) / 32) * 4;
-                            vvBuf[sub] = (qs[qsByte] >> qsShift) & 0x0F;
+                            var vw0 = Fma.MultiplySubtract(Q4KNibbles8(qs, basePos, l >> 3), vs, vm);
+                            var vw1 = Fma.MultiplySubtract(Q4KNibbles8(qs, basePos, (l >> 3) + 1), vs, vm);
+                            vacc0 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[basePos + l]), vw0, vacc0);
+                            vacc1 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[basePos + l + 8]), vw1, vacc1);
                         }
-                        var vv = Vector256.LoadUnsafe(ref vvBuf[0]);
-                        var vi = Vector256.LoadUnsafe(ref pIn[basePos + l]);
-                        var vw = Avx.Subtract(Avx.Multiply(vv, vs), vm);
-                        vacc = Fma.MultiplyAdd(vi, vw, vacc);
+                        for (; l <= subRem - 8; l += 8)
+                        {
+                            var vw = Fma.MultiplySubtract(Q4KNibbles8(qs, basePos, l >> 3), vs, vm);
+                            vacc0 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[basePos + l]), vw, vacc0);
+                        }
                     }
                     for (; l < subRem; l++)
                     {
@@ -742,7 +766,7 @@ public static partial class QuantizationKernels
                 }
             }
         }
-        sum += MathHelpers.HSum256_Avx(vacc);
+        sum += MathHelpers.HSum256_Avx(Avx.Add(vacc0, vacc1));
         return (float)sum;
     }
 

--- a/SharpMind.Core/Quantization/QuantizationKernels.Q5.cs
+++ b/SharpMind.Core/Quantization/QuantizationKernels.Q5.cs
@@ -37,6 +37,31 @@ public static partial class QuantizationKernels
         return (float)sum;
     }
 
+    /// <summary>
+    /// The unsigned 5-bit codes <c>8g..8g+7</c> of a Q5_0 block, as floats in
+    /// 0..31 (the caller applies <c>(q - 16) * d</c> as one FMA). The block's 32
+    /// low nibbles sit in 16 bytes (low nibbles first, then high), and its 32
+    /// fifth bits are one 32-bit mask, bit <c>i</c> for weight <c>i</c>. Nibbles
+    /// are widened straight from memory (vpmovzxbd); <paramref name="qhv"/> is
+    /// the mask broadcast once per block and each lane shifts its own bit down
+    /// (vpsrlvd) by <paramref name="bitOfLane"/> = <c>8g + lane</c>. No
+    /// per-weight scalar decode through a stack buffer, which cannot
+    /// store-forward into the vector load that would follow it.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe Vector256<float> Q5_0Codes8(byte* qs, int g, Vector256<uint> qhv, Vector256<uint> bitOfLane)
+    {
+        var nib = Avx2.ConvertToVector256Int32(qs + (g & 1) * 8);
+        nib = g < 2 ? Avx2.And(nib, Vector256.Create(0x0F)) : Avx2.ShiftRightLogical(nib, 4);
+        var hi = Avx2.And(Avx2.ShiftRightLogicalVariable(qhv, bitOfLane), Vector256.Create(1u));
+        return Avx.ConvertToVector256Single(Avx2.Or(nib, Avx2.ShiftLeftLogical(hi, 4).AsInt32()));
+    }
+
+    private static readonly Vector256<uint> Q5Bits0 = Vector256.Create(0u, 1, 2, 3, 4, 5, 6, 7);
+    private static readonly Vector256<uint> Q5Bits1 = Vector256.Create(8u, 9, 10, 11, 12, 13, 14, 15);
+    private static readonly Vector256<uint> Q5Bits2 = Vector256.Create(16u, 17, 18, 19, 20, 21, 22, 23);
+    private static readonly Vector256<uint> Q5Bits3 = Vector256.Create(24u, 25, 26, 27, 28, 29, 30, 31);
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe float VecDotQ5_0_AVX2(float* input, byte* rawWeights, int col, int inFeatures)
     {
@@ -44,78 +69,6 @@ public static partial class QuantizationKernels
         const int QK = 32;
         int nBlocks = (inFeatures + QK - 1) / QK;
         double sum = 0;
-        float* vvBuf = stackalloc float[8];
-        for (int b = 0; b < nBlocks; b++)
-        {
-            byte* block = rawWeights + (long)col * nBlocks * BLOCK_BYTES + b * BLOCK_BYTES;
-            float d = HalfToFloat_F16C(*(ushort*)block);
-            uint qh = *(uint*)(block + 2);
-            byte* qs = block + 6;
-            int blockEnd = Math.Min(QK, inFeatures - b * QK);
-            float* pIn = input + b * QK;
-            var vd = Vector256.Create(d);
-            int half = QK / 2;
-
-            var vacc0 = Vector256<float>.Zero;
-            var vacc1 = Vector256<float>.Zero;
-            int i = 0;
-            for (; i <= blockEnd - 16; i += 16)
-            {
-                for (int sub = 0; sub < 8; sub++)
-                {
-                    int idx = i + sub;
-                    int h4 = ((int)(qh >> idx) & 1) << 4;
-                    int nib = (idx < half) ? (qs[idx] & 0x0F) : (qs[idx - half] >> 4);
-                    vvBuf[sub] = ((nib | h4) - 16) * d;
-                }
-                var vw0 = Vector256.LoadUnsafe(ref vvBuf[0]);
-                var vi0 = Vector256.LoadUnsafe(ref pIn[i]);
-                vacc0 = Avx.Add(vacc0, Avx.Multiply(vi0, vw0));
-
-                for (int sub = 0; sub < 8; sub++)
-                {
-                    int idx = i + 8 + sub;
-                    int h4 = ((int)(qh >> idx) & 1) << 4;
-                    int nib = (idx < half) ? (qs[idx] & 0x0F) : (qs[idx - half] >> 4);
-                    vvBuf[sub] = ((nib | h4) - 16) * d;
-                }
-                var vw1 = Vector256.LoadUnsafe(ref vvBuf[0]);
-                var vi1 = Vector256.LoadUnsafe(ref pIn[i + 8]);
-                vacc1 = Avx.Add(vacc1, Avx.Multiply(vi1, vw1));
-            }
-            for (; i <= blockEnd - 8; i += 8)
-            {
-                for (int sub = 0; sub < 8; sub++)
-                {
-                    int idx = i + sub;
-                    int h4 = ((int)(qh >> idx) & 1) << 4;
-                    int nib = (idx < half) ? (qs[idx] & 0x0F) : (qs[idx - half] >> 4);
-                    vvBuf[sub] = ((nib | h4) - 16) * d;
-                }
-                var vw = Vector256.LoadUnsafe(ref vvBuf[0]);
-                var vi = Vector256.LoadUnsafe(ref pIn[i]);
-                vacc0 = Avx.Add(vacc0, Avx.Multiply(vi, vw));
-            }
-            sum += MathHelpers.HSum256_Avx(Avx.Add(vacc0, vacc1));
-            for (; i < blockEnd; i++)
-            {
-                int h4 = ((int)(qh >> i) & 1) << 4;
-                int nib = (i < half) ? (qs[i] & 0x0F) : (qs[i - half] >> 4);
-                int q = nib | h4;
-                sum += pIn[i] * ((q - 16) * d);
-            }
-        }
-        return (float)sum;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe float VecDotQ5_0_FMA(float* input, byte* rawWeights, int col, int inFeatures)
-    {
-        const int BLOCK_BYTES = 22;
-        const int QK = 32;
-        int nBlocks = (inFeatures + QK - 1) / QK;
-        double sum = 0;
-        float* vvBuf = stackalloc float[8];
         var vacc0 = Vector256<float>.Zero;
         var vacc1 = Vector256<float>.Zero;
         for (int b = 0; b < nBlocks; b++)
@@ -129,42 +82,67 @@ public static partial class QuantizationKernels
             int half = QK / 2;
 
             int i = 0;
-            for (; i <= blockEnd - 16; i += 16)
+            if (blockEnd == QK)
             {
-                for (int sub = 0; sub < 8; sub++)
-                {
-                    int idx = i + sub;
-                    int h4 = ((int)(qh >> idx) & 1) << 4;
-                    int nib = (idx < half) ? (qs[idx] & 0x0F) : (qs[idx - half] >> 4);
-                    vvBuf[sub] = ((nib | h4) - 16) * d;
-                }
-                var vw0 = Vector256.LoadUnsafe(ref vvBuf[0]);
-                var vi0 = Vector256.LoadUnsafe(ref pIn[i]);
-                vacc0 = Fma.MultiplyAdd(vi0, vw0, vacc0);
-
-                for (int sub = 0; sub < 8; sub++)
-                {
-                    int idx = i + 8 + sub;
-                    int h4 = ((int)(qh >> idx) & 1) << 4;
-                    int nib = (idx < half) ? (qs[idx] & 0x0F) : (qs[idx - half] >> 4);
-                    vvBuf[sub] = ((nib | h4) - 16) * d;
-                }
-                var vw1 = Vector256.LoadUnsafe(ref vvBuf[0]);
-                var vi1 = Vector256.LoadUnsafe(ref pIn[i + 8]);
-                vacc1 = Fma.MultiplyAdd(vi1, vw1, vacc1);
+                var vd = Vector256.Create(d);
+                var v16d = Vector256.Create(16 * d);
+                var qhv = Vector256.Create(qh);
+                var w0 = Avx.Subtract(Avx.Multiply(Q5_0Codes8(qs, 0, qhv, Q5Bits0), vd), v16d);
+                var w1 = Avx.Subtract(Avx.Multiply(Q5_0Codes8(qs, 1, qhv, Q5Bits1), vd), v16d);
+                var w2 = Avx.Subtract(Avx.Multiply(Q5_0Codes8(qs, 2, qhv, Q5Bits2), vd), v16d);
+                var w3 = Avx.Subtract(Avx.Multiply(Q5_0Codes8(qs, 3, qhv, Q5Bits3), vd), v16d);
+                vacc0 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[0]), w0), vacc0);
+                vacc1 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[8]), w1), vacc1);
+                vacc0 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[16]), w2), vacc0);
+                vacc1 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[24]), w3), vacc1);
+                i = QK;
             }
-            for (; i <= blockEnd - 8; i += 8)
+            for (; i < blockEnd; i++)
             {
-                for (int sub = 0; sub < 8; sub++)
-                {
-                    int idx = i + sub;
-                    int h4 = ((int)(qh >> idx) & 1) << 4;
-                    int nib = (idx < half) ? (qs[idx] & 0x0F) : (qs[idx - half] >> 4);
-                    vvBuf[sub] = ((nib | h4) - 16) * d;
-                }
-                var vw = Vector256.LoadUnsafe(ref vvBuf[0]);
-                var vi = Vector256.LoadUnsafe(ref pIn[i]);
-                vacc0 = Fma.MultiplyAdd(vi, vw, vacc0);
+                int h4 = ((int)(qh >> i) & 1) << 4;
+                int nib = (i < half) ? (qs[i] & 0x0F) : (qs[i - half] >> 4);
+                int q = nib | h4;
+                sum += pIn[i] * ((q - 16) * d);
+            }
+        }
+        sum += MathHelpers.HSum256_Avx(Avx.Add(vacc0, vacc1));
+        return (float)sum;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe float VecDotQ5_0_FMA(float* input, byte* rawWeights, int col, int inFeatures)
+    {
+        const int BLOCK_BYTES = 22;
+        const int QK = 32;
+        int nBlocks = (inFeatures + QK - 1) / QK;
+        double sum = 0;
+        var vacc0 = Vector256<float>.Zero;
+        var vacc1 = Vector256<float>.Zero;
+        for (int b = 0; b < nBlocks; b++)
+        {
+            byte* block = rawWeights + (long)col * nBlocks * BLOCK_BYTES + b * BLOCK_BYTES;
+            float d = HalfToFloat_F16C(*(ushort*)block);
+            uint qh = *(uint*)(block + 2);
+            byte* qs = block + 6;
+            int blockEnd = Math.Min(QK, inFeatures - b * QK);
+            float* pIn = input + b * QK;
+            int half = QK / 2;
+
+            int i = 0;
+            if (blockEnd == QK)
+            {
+                var vd = Vector256.Create(d);
+                var v16d = Vector256.Create(16 * d);
+                var qhv = Vector256.Create(qh);
+                var w0 = Fma.MultiplySubtract(Q5_0Codes8(qs, 0, qhv, Q5Bits0), vd, v16d);
+                var w1 = Fma.MultiplySubtract(Q5_0Codes8(qs, 1, qhv, Q5Bits1), vd, v16d);
+                var w2 = Fma.MultiplySubtract(Q5_0Codes8(qs, 2, qhv, Q5Bits2), vd, v16d);
+                var w3 = Fma.MultiplySubtract(Q5_0Codes8(qs, 3, qhv, Q5Bits3), vd, v16d);
+                vacc0 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[0]), w0, vacc0);
+                vacc1 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[8]), w1, vacc1);
+                vacc0 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[16]), w2, vacc0);
+                vacc1 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[24]), w3, vacc1);
+                i = QK;
             }
             for (; i < blockEnd; i++)
             {

--- a/SharpMind.Core/Quantization/QuantizationKernels.Q6.cs
+++ b/SharpMind.Core/Quantization/QuantizationKernels.Q6.cs
@@ -72,6 +72,10 @@ public static partial class QuantizationKernels
         int colBlockStart = col * inFeatures % QK_K;
         int nBlocks = (inFeatures + QK_K - 1) / QK_K;
         double sum = 0;
+        var vacc0 = Vector256<float>.Zero;
+        var vacc1 = Vector256<float>.Zero;
+        var vacc2 = Vector256<float>.Zero;
+        var vacc3 = Vector256<float>.Zero;
         for (int b = 0; b < nBlocks; b++)
         {
             byte* block = rawWeights + (long)(startBlock + b) * BLOCK_BYTES;
@@ -90,7 +94,24 @@ public static partial class QuantizationKernels
                 sbyte* psc = scales + (nOff == 0 ? 0 : 8);
 
                 int halfRem = Math.Min(128, blockEnd - nOff);
-                for (int l = 0; l < 32 && l < halfRem; l++)
+
+                int l = 0;
+                for (; l + 103 < halfRem && l < 32; l += 8)
+                {
+                    int is_ = l / 16;
+                    Q6KCodes8(pql, pqh, l, out var q1, out var q2, out var q3, out var q4);
+                    float s1 = d * psc[is_ + 0], s2 = d * psc[is_ + 2], s3 = d * psc[is_ + 4], s4 = d * psc[is_ + 6];
+                    var vw1 = Avx.Subtract(Avx.Multiply(q1, Vector256.Create(s1)), Vector256.Create(32 * s1));
+                    var vw2 = Avx.Subtract(Avx.Multiply(q2, Vector256.Create(s2)), Vector256.Create(32 * s2));
+                    var vw3 = Avx.Subtract(Avx.Multiply(q3, Vector256.Create(s3)), Vector256.Create(32 * s3));
+                    var vw4 = Avx.Subtract(Avx.Multiply(q4, Vector256.Create(s4)), Vector256.Create(32 * s4));
+                    vacc0 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[nOff + l]), vw1), vacc0);
+                    vacc1 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[nOff + l + 32]), vw2), vacc1);
+                    vacc2 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[nOff + l + 64]), vw3), vacc2);
+                    vacc3 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[nOff + l + 96]), vw4), vacc3);
+                }
+
+                for (; l < halfRem && l < 32; l++)
                 {
                     int is_ = l / 16;
                     int q1v = (pql[l] & 0x0F) | ((pqh[l] & 0x03) << 4);
@@ -123,7 +144,37 @@ public static partial class QuantizationKernels
                 }
             }
         }
+        sum += MathHelpers.HSum256_Avx(Avx.Add(Avx.Add(vacc0, vacc1), Avx.Add(vacc2, vacc3)));
         return (float)sum;
+    }
+
+    /// <summary>
+    /// The four 8-weight groups a Q6_K half-block stores interleaved at offset
+    /// <paramref name="l"/>: values <c>l..l+7</c>, <c>+32</c>, <c>+64</c> and
+    /// <c>+96</c>, as unsigned 6-bit codes in float (0..63; the caller applies
+    /// <c>(q - 32) * d * scale</c> as one FMA). Low nibbles of <c>ql[l]</c> and
+    /// <c>ql[l+32]</c> carry the first two, high nibbles the last two, and byte
+    /// <c>qh[l]</c> holds each group's top two bits in successive bit pairs. All
+    /// of it is widened straight from memory (vpmovzxbd) and assembled with
+    /// vector shifts and masks — no per-weight scalar decode through a stack
+    /// buffer, which cannot store-forward into the vector load that would follow.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe void Q6KCodes8(byte* pql, byte* pqh, int l,
+        out Vector256<float> q1, out Vector256<float> q2, out Vector256<float> q3, out Vector256<float> q4)
+    {
+        var lo = Avx2.ConvertToVector256Int32(pql + l);
+        var lo2 = Avx2.ConvertToVector256Int32(pql + l + 32);
+        var h = Avx2.ConvertToVector256Int32(pqh + l);
+        var m0F = Vector256.Create(0x0F);
+        var m03 = Vector256.Create(0x03);
+
+        // Bytes are < 256, so a plain right shift by 4 or 6 already isolates the
+        // high field; only the middle fields need masking.
+        q1 = Avx.ConvertToVector256Single(Avx2.Or(Avx2.And(lo, m0F), Avx2.ShiftLeftLogical(Avx2.And(h, m03), 4)));
+        q2 = Avx.ConvertToVector256Single(Avx2.Or(Avx2.And(lo2, m0F), Avx2.ShiftLeftLogical(Avx2.And(Avx2.ShiftRightLogical(h, 2), m03), 4)));
+        q3 = Avx.ConvertToVector256Single(Avx2.Or(Avx2.ShiftRightLogical(lo, 4), Avx2.ShiftLeftLogical(Avx2.And(Avx2.ShiftRightLogical(h, 4), m03), 4)));
+        q4 = Avx.ConvertToVector256Single(Avx2.Or(Avx2.ShiftRightLogical(lo2, 4), Avx2.ShiftLeftLogical(Avx2.ShiftRightLogical(h, 6), 4)));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -134,7 +185,6 @@ public static partial class QuantizationKernels
         int colBlockStart = col * inFeatures % QK_K;
         int nBlocks = (inFeatures + QK_K - 1) / QK_K;
         double sum = 0;
-        float* vvBuf = stackalloc float[8];
         var vacc0 = Vector256<float>.Zero;
         var vacc1 = Vector256<float>.Zero;
         var vacc2 = Vector256<float>.Zero;
@@ -162,39 +212,16 @@ public static partial class QuantizationKernels
                 for (; l + 103 < halfRem && l < 32; l += 8)
                 {
                     int is_ = l / 16;
-                    int sOff = is_ == 0 ? 0 : 1;
-
-                    for (int sub = 0; sub < 8; sub++)
-                    {
-                        int idx = l + sub;
-                        int q1v = (pql[idx] & 0x0F) | ((pqh[idx] & 0x03) << 4);
-                        vvBuf[sub] = d * psc[sOff + 0] * (q1v - 32);
-                    }
-                    vacc0 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[nOff + l]), Vector256.LoadUnsafe(ref vvBuf[0]), vacc0);
-
-                    for (int sub = 0; sub < 8; sub++)
-                    {
-                        int idx = l + sub;
-                        int q2v = (pql[idx + 32] & 0x0F) | (((pqh[idx] >> 2) & 0x03) << 4);
-                        vvBuf[sub] = d * psc[sOff + 2] * (q2v - 32);
-                    }
-                    vacc1 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[nOff + l + 32]), Vector256.LoadUnsafe(ref vvBuf[0]), vacc1);
-
-                    for (int sub = 0; sub < 8; sub++)
-                    {
-                        int idx = l + sub;
-                        int q3v = ((pql[idx] >> 4) & 0x0F) | (((pqh[idx] >> 4) & 0x03) << 4);
-                        vvBuf[sub] = d * psc[sOff + 4] * (q3v - 32);
-                    }
-                    vacc2 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[nOff + l + 64]), Vector256.LoadUnsafe(ref vvBuf[0]), vacc2);
-
-                    for (int sub = 0; sub < 8; sub++)
-                    {
-                        int idx = l + sub;
-                        int q4v = ((pql[idx + 32] >> 4) & 0x0F) | (((pqh[idx] >> 6) & 0x03) << 4);
-                        vvBuf[sub] = d * psc[sOff + 6] * (q4v - 32);
-                    }
-                    vacc3 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[nOff + l + 96]), Vector256.LoadUnsafe(ref vvBuf[0]), vacc3);
+                    Q6KCodes8(pql, pqh, l, out var q1, out var q2, out var q3, out var q4);
+                    float s1 = d * psc[is_ + 0], s2 = d * psc[is_ + 2], s3 = d * psc[is_ + 4], s4 = d * psc[is_ + 6];
+                    var vw1 = Fma.MultiplySubtract(q1, Vector256.Create(s1), Vector256.Create(32 * s1));
+                    var vw2 = Fma.MultiplySubtract(q2, Vector256.Create(s2), Vector256.Create(32 * s2));
+                    var vw3 = Fma.MultiplySubtract(q3, Vector256.Create(s3), Vector256.Create(32 * s3));
+                    var vw4 = Fma.MultiplySubtract(q4, Vector256.Create(s4), Vector256.Create(32 * s4));
+                    vacc0 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[nOff + l]), vw1, vacc0);
+                    vacc1 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[nOff + l + 32]), vw2, vacc1);
+                    vacc2 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[nOff + l + 64]), vw3, vacc2);
+                    vacc3 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[nOff + l + 96]), vw4, vacc3);
                 }
 
                 for (; l < halfRem && l < 32; l++)

--- a/SharpMind.Inference/Chat/ChatSession.cs
+++ b/SharpMind.Inference/Chat/ChatSession.cs
@@ -25,20 +25,6 @@ public sealed class ChatSession<T, K> : IChatSession where K : IKVCacheBuilder, 
     private readonly bool _addEos;
     private bool _initialized;
     private bool _disposed;
-    private int[]? _cachedPromptTokens;
-    /// <summary>
-    /// True when the generator's KV cache is known to correspond exactly to
-    /// <see cref="_cachedPromptTokens"/> plus whatever the model generated on
-    /// top of it last turn, so the next turn can extend the cache incrementally
-    /// instead of reprocessing the whole conversation from scratch.
-    /// Set false by anything that leaves the cache's actual contents unknown or
-    /// out of sync with history: compaction, message eviction / context
-    /// trimming, snapshot loads, sub-agent calls (which repurpose the same
-    /// generator/cache), a prompt formatter being in use, generators that don't
-    /// report how many tokens they committed (<see cref="IGenerator{T}.CurrentGeneratedIds"/>
-    /// is null), and interrupted/cancelled generations.
-    /// </summary>
-    private bool _cacheValid;
     private IReadOnlyList<ChatMessage>? _filteredHistoryCache;
     private IReadOnlyList<ChatMessage>? _promptHistoryCache;
     // IO interceptors (optional)
@@ -281,8 +267,6 @@ public sealed class ChatSession<T, K> : IChatSession where K : IKVCacheBuilder, 
         InvalidateHistoryCache();
 _pendingDraft = null;
         if (_agentBuilder != null) AddAgentMessages();
-        _cachedPromptTokens = null;
-        _cacheValid = false;
         _generator.ResetCache();
     }
 
@@ -412,8 +396,6 @@ _pendingDraft = null;
             _history.Clear();
             _history.AddRange(surviving);
             InvalidateHistoryCache();
-            _cachedPromptTokens = null;
-            _cacheValid = false;
 
             promptToks = _tokenizer.Encode(BuildPrompt(), addBos: false, addEos: false);
         }
@@ -425,13 +407,52 @@ _pendingDraft = null;
             var subset = GC.AllocateUninitializedArray<int>(contextBudget);
             promptToks.AsSpan(start, contextBudget).CopyTo(subset);
             promptToks = subset;
-            // The token array fed to the generator no longer lines up with
-            // whatever is physically resident in the KV cache (we just cut
-            // tokens from the front), so the cache must be rebuilt from scratch.
-            _cacheValid = false;
+            // Cutting tokens from the front means nothing resident in the KV
+            // cache lines up with this any more; the prefix match in
+            // FeedForPrompt sees that and rebuilds from scratch.
         }
 
         return promptToks;
+    }
+
+    /// <summary>
+    /// Decides what to feed the generator for <paramref name="promptToks"/>, the
+    /// full prompt as rendered now. Whatever the KV cache already holds for the
+    /// leading tokens is kept and only the rest is fed: the cache is compared
+    /// token by token against the prompt (<see cref="IGenerator{T}.CacheTokens"/>),
+    /// truncated to the common prefix, and generation resumes from there.
+    ///
+    /// Comparing tokens rather than remembering "what we sent last turn" is what
+    /// makes this hold for every formatter and every history edit at once. A
+    /// second turn under ChatML extends the previous prompt plus the response the
+    /// model itself generated, so almost everything matches. Compaction, an
+    /// evicted message, thinking stripped from an assistant turn, or a response
+    /// that re-tokenises differently from how it was generated all just move the
+    /// divergence point earlier, and only what follows it is recomputed. A cache
+    /// the generator cannot vouch for (null) or one with nothing in common is
+    /// reset and the whole prompt is fed.
+    ///
+    /// At least one token is always fed, even when the cache already covers the
+    /// whole prompt: the generator needs a forward pass to have logits to sample.
+    /// </summary>
+    private int[] FeedForPrompt(int[] promptToks)
+    {
+        var cached = _generator.CacheTokens;
+        int keep = 0;
+        if (cached is not null)
+        {
+            int limit = Math.Min(cached.Count, promptToks.Length - 1);
+            while (keep < limit && cached[keep] == promptToks[keep]) keep++;
+        }
+
+        if (keep == 0)
+        {
+            _generator.ResetCache();
+            return promptToks;
+        }
+
+        _generator.TruncateCache(keep);
+        return promptToks[keep..];
     }
 
     public async ValueTask DisposeAsync()
@@ -613,11 +634,9 @@ private void ThrowIfDisposed()
 
         var promptToks = _tokenizer.Encode(prompt, addBos: _addBos, addEos: false);
 
+        // An unrelated prompt on the shared generator: the parent conversation's
+        // cache is gone after this, and the next turn's prefix match rebuilds it.
         _generator.ResetCache();
-        // The sub-agent call above just repurposed the shared generator's KV
-        // cache for an unrelated prompt. The parent conversation's cache is no
-        // longer resident, so the next turn must do a full rebuild.
-        _cacheValid = false;
 
         var sb = new System.Text.StringBuilder();
         await foreach (var fragment in _generator.GenerateFromTokensAsync(promptToks, sampleCfg, genCfg, ct))
@@ -691,53 +710,10 @@ private void ThrowIfDisposed()
         // rather than a tool call, or until MaxToolCallsPerTurn is reached.
         for (int toolCallCount = 0; ; toolCallCount++)
         {
-            // Tokenise.
-            // `promptToks` is always the *full logical* prompt (used for budget
-            // checks, compaction, and next turn's bookkeeping); `generatorInput`
-            // is what we actually feed the generator this call, which is just
-            // the unseen delta when the KV cache can be safely extended.
-            int[] promptToks;
-            int[] generatorInput;
-            bool canIncrement = _cacheValid
-                && _cachedPromptTokens is not null
-                && _formatter is null
-                && _history.Count >= 2
-                && _history[^2].Role == ChatRole.Agent;
-
-            if (canIncrement)
-            {
-                // Full logical prompt, for bookkeeping only — mirrors what
-                // BuildPrompt() would produce, so budget/eviction logic below
-                // keeps working exactly as before.
-                var incremental = new System.Text.StringBuilder();
-                incremental.Append(_history[^2].Content).Append('\n');
-                incremental.Append("user: ").Append(userInput).Append("\nassistant: ");
-                int[] newToks = _tokenizer.Encode(incremental.ToString(), addBos: false, addEos: false);
-
-                promptToks = GC.AllocateUninitializedArray<int>(_cachedPromptTokens!.Length + newToks.Length);
-                _cachedPromptTokens.CopyTo(promptToks.AsSpan());
-                newToks.CopyTo(promptToks.AsSpan(_cachedPromptTokens.Length));
-
-                // What we actually send: the previous assistant turn's content
-                // is already resident in the KV cache from when it was
-                // generated, so only the closing newline and the new turn are
-                // "new" tokens. NOTE: encoding this suffix separately from the
-                // full string above can, in principle, tokenise the boundary
-                // (the char right after the previous assistant content)
-                // slightly differently than one joint BPE pass would — a
-                // known limitation of incremental/delta tokenisation. In
-                // practice this only risks the token(s) right at the seam,
-                // not the already-cached content before it.
-                var delta = new System.Text.StringBuilder();
-                delta.Append('\n').Append("user: ").Append(userInput).Append("\nassistant: ");
-                generatorInput = _tokenizer.Encode(delta.ToString(), addBos: false, addEos: false);
-            }
-            else
-            {
-                var prompt = BuildPrompt();
-                promptToks = _tokenizer.Encode(prompt, addBos: false, addEos: false);
-                generatorInput = promptToks;
-            }
+            // `promptToks` is the full prompt as the formatter renders it right
+            // now; what actually goes to the generator is decided in
+            // FeedForPrompt below, once compaction and trimming have had their say.
+            int[] promptToks = _tokenizer.Encode(BuildPrompt(), addBos: false, addEos: false);
 
             // Context compaction
             var compactor = _agentBuilder?.Compactor;
@@ -763,36 +739,17 @@ private void ThrowIfDisposed()
                 if (await compactor.ShouldCompactAsync(cmpCtx, ct) && await compactor.CompactAsync(cmpCtx, ct))
                 {
                     InvalidateHistoryCache();
-                    _cachedPromptTokens = null;
-                    _cacheValid = false;
                     promptToks = _tokenizer.Encode(BuildPrompt(), addBos: false, addEos: false);
-                    generatorInput = promptToks;
                 }
             }
 
             if (promptToks.Length > MaxTokens)
-            {
-                promptToks = TrimToFitContext(promptToks); // may itself set _cacheValid = false
-                generatorInput = promptToks;
-            }
+                promptToks = TrimToFitContext(promptToks);
 
             if (promptToks.Length == 0)
                 throw new InvalidOperationException("Prompt produced no token IDs; cannot generate.");
 
-            // Only reset the KV cache when something above invalidated it —
-            // this is the one case that used to run unconditionally every
-            // turn, forcing a full reprocessing of the whole conversation.
-            if (!_cacheValid)
-            {
-                _generator.ResetCache();
-                generatorInput = promptToks; // cache is gone; must resend everything
-            }
-
-            _cachedPromptTokens = promptToks;
-            // Provisionally invalid until generation completes cleanly below —
-            // if this turn throws (cancellation, error) partway through
-            // streaming, we must not assume next turn's cache state is known.
-            _cacheValid = false;
+            int[] generatorInput = FeedForPrompt(promptToks);
 
             var sampleCfg = new SamplingConfig
             {
@@ -939,9 +896,6 @@ private void ThrowIfDisposed()
                     Content = $"Tool result: {toolResult.ToJsonString()}"
                 });
                 InvalidateHistoryCache();
-
-                _cachedPromptTokens = null; // history grew; invalidate incremental cache
-                _cacheValid = false;
                 continue;                   // generate again with enriched history
             }
 
@@ -1016,9 +970,6 @@ private void ThrowIfDisposed()
                     Content = $"Tool result: {agentResult}"
                 });
                 InvalidateHistoryCache();
-
-                _cachedPromptTokens = null; // history grew; invalidate incremental cache
-                _cacheValid = false;
                 continue;                   // generate again with enriched history
             }
 
@@ -1036,8 +987,6 @@ private void ThrowIfDisposed()
                     Content = $"Tool result: {{\"status\":\"error\",\"message\":\"Maximum agent depth ({MaxAgentDepth}) reached. Cannot delegate further.\"}}"
                 });
                 InvalidateHistoryCache();
-                _cachedPromptTokens = null;
-                _cacheValid = false;
                 continue;
             }
 
@@ -1050,16 +999,6 @@ private void ThrowIfDisposed()
                 _history.Add(agentMsg);
                 InvalidateHistoryCache();
             }
-
-            // Generation completed cleanly: the KV cache now holds exactly
-            // _cachedPromptTokens plus whatever was just generated, so the
-            // next turn can extend it incrementally — but only if the
-            // generator actually reports how many tokens it committed. Some
-            // generators (e.g. speculative/Medusa) don't implement
-            // CurrentGeneratedIds, in which case we can't safely trust the
-            // cache's exact length, so we conservatively fall back to a full
-            // rebuild next turn.
-            _cacheValid = _generator.CurrentGeneratedIds is not null;
 
             yield return new ChatStreamEntry
             {
@@ -1211,9 +1150,6 @@ _history.Clear();
             if (msg.Role != ChatRole.System)
                 _history.Add(msg);
         InvalidateHistoryCache();
-
-        _cachedPromptTokens = null;
-        _cacheValid = false;
         _generator.ResetCache();
     }
 

--- a/SharpMind.Inference/IGenerator.cs
+++ b/SharpMind.Inference/IGenerator.cs
@@ -30,4 +30,24 @@ public interface IGenerator<T> : IDisposable where T : IKVCacheBuilder, new()
     float? CumulativeTokensPerSecond { get; }
     float? TimeToFirstToken { get; }
     IReadOnlyList<int>? CurrentGeneratedIds => null;
+
+    /// <summary>
+    /// The token ids whose keys and values are resident in the KV cache, in
+    /// position order — every prompt token that was prefilled plus every
+    /// generated token that was fed back through the model — or
+    /// <see langword="null"/> when the generator cannot vouch for the cache's
+    /// contents (it never tracked them, or a sliding-window trim has moved
+    /// entries away from their original positions). A caller that wants to
+    /// continue a conversation compares its new prompt against this, keeps the
+    /// common prefix with <see cref="TruncateCache"/>, and feeds only the rest.
+    /// </summary>
+    IReadOnlyList<int>? CacheTokens => null;
+
+    /// <summary>
+    /// Drops every cached position at or beyond <paramref name="length"/>, so the
+    /// next generation continues from position <paramref name="length"/>. Valid
+    /// because position <c>i</c> depends only on tokens before it. Generators
+    /// that do not track their cache may simply reset it.
+    /// </summary>
+    void TruncateCache(int length) => ResetCache();
 }

--- a/SharpMind.Inference/MedusaGenerator.cs
+++ b/SharpMind.Inference/MedusaGenerator.cs
@@ -493,6 +493,12 @@ public sealed class MedusaGenerator<T> : IGenerator<T> where T : IKVCacheBuilder
             _caches[i].Reset();
     }
 
+    public void TruncateCache(int length)
+    {
+        for (int i = 0; i < _caches.Length; i++)
+            _caches[i].Truncate(length);
+    }
+
     public float CacheFillRatio => (float)_caches[0].Length / _caches[0].MaxSeqLen;
 
     public float? TokensPerSecond { get; private set; }

--- a/SharpMind.Inference/SpeculativeGenerator.cs
+++ b/SharpMind.Inference/SpeculativeGenerator.cs
@@ -334,6 +334,12 @@ public sealed class SpeculativeGenerator<T> : IGenerator<T> where T : IKVCacheBu
             _caches[i].Reset();
     }
 
+    public void TruncateCache(int length)
+    {
+        for (int i = 0; i < _caches.Length; i++)
+            _caches[i].Truncate(length);
+    }
+
     public float CacheFillRatio => (float)_caches[0].Length / _caches[0].MaxSeqLen;
 
     public float? TokensPerSecond { get; private set; }

--- a/SharpMind.Inference/StandardGenerator.cs
+++ b/SharpMind.Inference/StandardGenerator.cs
@@ -36,6 +36,12 @@ public sealed class StandardGenerator<T> : IGenerator<T> where T : IKVCacheBuild
     private readonly bool _addBos;
     private List<int>? _generatedIds;
     private readonly bool _addEos;
+    /// <summary>
+    /// Ids resident in <see cref="_caches"/>, position by position; null once
+    /// the cache's contents can no longer be vouched for (a sliding-window trim,
+    /// or caches that were handed in already holding entries).
+    /// </summary>
+    private List<int>? _cacheTokens;
 
     public StandardGenerator(
         Transformer   model,
@@ -67,6 +73,7 @@ public sealed class StandardGenerator<T> : IGenerator<T> where T : IKVCacheBuild
                 _caches[i] = new T().CreateKVCache(1, numKvHeads, maxSeqLen, headDim);
         }
 
+        _cacheTokens = _caches[0].Length == 0 ? [] : null;
         _defaultRng = seed.HasValue ? new Random(seed.Value) : Random.Shared;
         _workspace = new Core.Memory.Workspace(SharpMind.Core.Memory.Workspace.CalculateRequiredSize(model.Config.HiddenDim,model.Config.FfnDim,model.Config.VocabSize,model.Config.NumLayers, model.Config.MaxSeqLen));
     }
@@ -116,7 +123,10 @@ public sealed class StandardGenerator<T> : IGenerator<T> where T : IKVCacheBuild
         {
                         // Prefill (chunked so long prompts fit the workspace; see Prefill)
             int posOffset = _caches[0].Length;
+            // Someone else moved the cache under us: stop vouching for it.
+            if (_cacheTokens is not null && _cacheTokens.Count != posOffset) _cacheTokens = null;
             logitsTensor = Prefill.ForwardLastLogitsChunked(_model, _caches, promptIds, _workspace, PrefillProgress);
+            _cacheTokens?.AddRange(promptIds);
 
 
             int vocabSize = logitsTensor.Shape[1];
@@ -213,6 +223,9 @@ public sealed class StandardGenerator<T> : IGenerator<T> where T : IKVCacheBuild
                         : cache0.MaxSeqLen / 2;
                     for (int i = 0; i < cachesLen; i++)
                         _caches[i].TrimToLast(keep);
+                    // Entries now sit at positions they were not computed for;
+                    // nothing about the cache is a prefix of any prompt any more.
+                    _cacheTokens = null;
                 }
 
                 Tensor<float>? prevTensor = logitsTensor;
@@ -225,6 +238,7 @@ public sealed class StandardGenerator<T> : IGenerator<T> where T : IKVCacheBuild
                 _decodeTokenScratch[0] = nextId;
                 stepInput.Data[0] = nextId;
                 logitsTensor = _model.ForwardLastLogits(stepInput, _caches, newPos, _workspace);
+                _cacheTokens?.Add(nextId);
             }
 
             if (!genCfg.Stream)
@@ -262,6 +276,17 @@ public sealed class StandardGenerator<T> : IGenerator<T> where T : IKVCacheBuild
     {
         for (int i = 0; i < _caches.Length; i++)
             _caches[i].Reset();
+        _cacheTokens = [];
+    }
+
+    public IReadOnlyList<int>? CacheTokens => _cacheTokens;
+
+    public void TruncateCache(int length)
+    {
+        for (int i = 0; i < _caches.Length; i++)
+            _caches[i].Truncate(length);
+        if (_cacheTokens is not null && _cacheTokens.Count > length)
+            _cacheTokens.RemoveRange(length, _cacheTokens.Count - length);
     }
 
     /// <summary>KV-cache fill as a fraction of maximum capacity.</summary>

--- a/SharpMind.Tests/Inference/ChatSessionKvReuseTests.cs
+++ b/SharpMind.Tests/Inference/ChatSessionKvReuseTests.cs
@@ -1,0 +1,242 @@
+using SharpMind.Core;
+using SharpMind.Core.Tensors;
+using SharpMind.Inference;
+using SharpMind.Inference.Chat;
+using SharpMind.Inference.Chat.PromptFormatters;
+using SharpMind.Model;
+using SharpMind.Model.Config;
+using SharpMind.Tokenization;
+using SharpMind.Tokenization.Vocab;
+using SharpMind.Training;
+using Xunit;
+
+namespace SharpMind.Tests.Inference;
+
+/// <summary>
+/// A second chat turn must not re-run the whole conversation through the model.
+/// The KV cache already holds the previous prompt and the response the model
+/// generated on top of it; only the tokens after that are new. This used to
+/// work only without a chat formatter (a hand-built "user: … assistant: "
+/// delta), so every real instruct model — ChatML, Llama-3, Auto — paid the full
+/// prefill on every turn, growing with history.
+///
+/// The session now compares the rendered prompt token by token against what the
+/// generator says is resident, keeps the common prefix, and feeds the rest.
+/// These tests watch the cache itself: a spy records the sequence length of
+/// every forward pass, so the first entry of a turn is exactly how many prompt
+/// tokens were prefilled — measured, not inferred. The expected value is the
+/// tokens after the common prefix of the previous cache contents and the new
+/// prompt, computed here the same way the session must.
+/// </summary>
+public sealed class ChatSessionKvReuseTests
+{
+    private const int MaxNew = 6;
+    private const string SystemPrompt = "Be terse.";
+
+    private static ModelConfig Cfg => new()
+    {
+        VocabSize = 256,
+        HiddenDim = 8,
+        NumLayers = 1,
+        NumHeads = 2,
+        NumKvHeads = 2,
+        FfnDim = 16,
+        MaxSeqLen = 1024,
+    };
+
+    // 256 byte tokens and no specials, so a random model's argmax always decodes
+    // to a real byte that re-encodes to the same id: replies are never empty and
+    // the recorded response round-trips to the ids the cache holds.
+    private static Tokenizer BuildTokenizer()
+    {
+        var tokens = new List<string>();
+        for (int b = 0; b < 256; b++) tokens.Add(Vocabulary.ByteTokenString(b));
+        return Tokenizer.FromGguf([.. tokens], merges: null, tokenTypes: null, bosId: -1, eosId: -1);
+    }
+
+    private static Transformer BuildModel()
+    {
+        var sharpConfig = SharpMindConfig.Gpt with { Hardware = HardwareTier.Scalar };
+        var weights = ModelFactory.CreateForTraining(Cfg, sharpConfig);
+        WeightInitializer.InitializeRandomly(weights, 1234);
+        return ModelFactory.CreateTrainingTransformer(weights, sharpConfig);
+    }
+
+    /// <summary>Records the sequence length of every write, so prefill sizes are observable.</summary>
+    private sealed class SpyCache(IKVCache inner) : IKVCache
+    {
+        public readonly List<int> Writes = [];
+        public int FirstWrite => Writes.Count > 0 ? Writes[0] : 0;
+        public int Total => Writes.Sum();
+        public void Update(Tensor<float> k, Tensor<float> v, int numKvHeads, int headDim)
+        {
+            Writes.Add(k.Shape[1]);
+            inner.Update(k, v, numKvHeads, headDim);
+        }
+        public void Reset() => inner.Reset();
+        public void TrimToLast(int keep) => inner.TrimToLast(keep);
+        public void Truncate(int length) => inner.Truncate(length);
+        public int Length => inner.Length;
+        public int MaxSeqLen => inner.MaxSeqLen;
+        public bool IsFull => inner.IsFull;
+        public bool IsContiguous => inner.IsContiguous;
+        public unsafe float* GetKeyPtr(int b, int p, int h) => inner.GetKeyPtr(b, p, h);
+        public unsafe float* GetValuePtr(int b, int p, int h) => inner.GetValuePtr(b, p, h);
+        public object? Snapshot() => inner.Snapshot();
+        public void Restore(object? s) => inner.Restore(s);
+        public void Dispose() => inner.Dispose();
+    }
+
+    private static (ChatSession<StandardGeneratorBuilder<KVCacherBuilder>, KVCacherBuilder> session, SpyCache spy)
+        BuildSession(Transformer model, Tokenizer tokenizer, IChatPromptFormatter formatter)
+    {
+        var spy = new SpyCache(new KVCache(1, Cfg.NumKvHeads, Cfg.MaxSeqLen, Cfg.HeadDim));
+        var session = new ChatSession<StandardGeneratorBuilder<KVCacherBuilder>, KVCacherBuilder>(
+            model, tokenizer, caches: [spy], formatter: formatter)
+        {
+            MaxNewTokens = MaxNew,
+            Temperature = 0f,          // greedy, so two runs of the same prompt agree
+            RepetitionPenalty = 1f,    // the penalty window would otherwise treat a delta differently
+        };
+        session.InitializeChat();
+        session.AddMessage(ChatRole.System, SystemPrompt);
+        return (session, spy);
+    }
+
+    private static async Task<List<int>> Turn(
+        ChatSession<StandardGeneratorBuilder<KVCacherBuilder>, KVCacherBuilder> session, string text)
+    {
+        var ids = new List<int>();
+        await foreach (var e in session.GetResponseStreamAsync(text))
+            if (e.TokenId is int id) ids.Add(id);
+        return ids;
+    }
+
+    private static int[] Encode(Tokenizer t, string s) => t.Encode(s, addBos: false, addEos: false);
+
+    private static int CommonPrefix(IReadOnlyList<int> a, int[] b)
+    {
+        int n = Math.Min(a.Count, b.Length), i = 0;
+        while (i < n && a[i] == b[i]) i++;
+        return i;
+    }
+
+    // The exact ids a just-finished turn ran on, taken from the cache rather than
+    // re-encoded: after a turn the cache holds the whole prompt followed by the
+    // reply, so dropping the last `replyLen` positions leaves the prompt ids the
+    // generator actually saw — no re-tokenisation, no seam artifacts.
+    private static int[] LastPrompt(
+        ChatSession<StandardGeneratorBuilder<KVCacherBuilder>, KVCacherBuilder> session, int replyLen)
+    {
+        var cache = session.Generator.CacheTokens!;
+        return [.. cache.Take(cache.Count - replyLen)];
+    }
+
+    public static IEnumerable<object[]> Formatters()
+    {
+        yield return [new SimpleFormatter()];                 // "user: … assistant: ", the only shape that ever reused
+        yield return [new ChatMLFormatter("<|im_start|>")];    // what qwen2 uses
+    }
+
+    [Theory]
+    [MemberData(nameof(Formatters))]
+    public async Task SecondTurn_PrefillsOnlyTheTokensAfterTheCachedPrefix(IChatPromptFormatter formatter)
+    {
+        using var model = BuildModel();
+        var tokenizer = BuildTokenizer();
+        var (session, spy) = BuildSession(model, tokenizer, formatter);
+        await using var _ = session;
+
+        var reply1 = await Turn(session, "hello there");
+        int turn1Prompt = LastPrompt(session, reply1.Count).Length;   // system + first user turn + assistant header
+        var cacheBefore = session.Generator.CacheTokens!.ToArray();
+
+        spy.Writes.Clear();
+        var reply2 = await Turn(session, "and again");
+
+        // Turn 2's prompt begins with the whole first turn, so the system prompt
+        // and first user turn are never re-prefilled — the headline win. (Whether
+        // the reply itself is reused depends on the reply re-tokenising to the
+        // same ids it was generated as; that is the tokenizer's business, not
+        // this mechanism's, so the floor is turn 1's prompt.)
+        var prompt2 = LastPrompt(session, reply2.Count);
+        int keep = CommonPrefix(cacheBefore, prompt2);
+        Assert.True(keep >= turn1Prompt,
+            $"reused only {keep} tokens; the {turn1Prompt}-token system+user prefix must always be kept");
+        Assert.True(keep < prompt2.Length);
+        // Positions written this turn = the prompt tail past the reused prefix,
+        // then one per generated token. (Prefill is chunked at MaxPrefillTokens,
+        // so sum the writes rather than reading the first.)
+        Assert.Equal((prompt2.Length - keep) + reply2.Count, spy.Total);
+    }
+
+    [Theory]
+    [MemberData(nameof(Formatters))]
+    public async Task ReusedPrefix_GeneratesTheSameTokensAsAFreshPrefill(IChatPromptFormatter formatter)
+    {
+        using var model = BuildModel();
+        var tokenizer = BuildTokenizer();
+
+        // Session A: two turns, the second extending the cache from the first.
+        var (a, _) = BuildSession(model, tokenizer, formatter);
+        await using var _a = a;
+        await Turn(a, "hello there");
+        var replyA1 = a.History[^1].Content;
+        var idsA2 = await Turn(a, "and again");
+
+        // Session B: same conversation assembled by hand, so its "and again" turn
+        // is its first generation and prefills the whole prompt from empty.
+        var (b, spyB) = BuildSession(model, tokenizer, formatter);
+        await using var _b = b;
+        b.AddMessage(ChatRole.User, "hello there");
+        b.AddMessage(ChatRole.Agent, replyA1);
+        var idsB2 = await Turn(b, "and again");
+
+        Assert.NotEmpty(idsA2);
+        Assert.Equal(idsB2, idsA2);                 // reuse must not change a single sampled token
+        // Sanity that B really did the full prefill it stands in for: its one and
+        // only prefill covers the whole prompt, more than A reused.
+        Assert.True(spyB.FirstWrite > 1);
+    }
+
+    [Fact]
+    public async Task EditedHistory_RecomputesFromTheDivergencePointOnly()
+    {
+        using var model = BuildModel();
+        var tokenizer = BuildTokenizer();
+        var formatter = new ChatMLFormatter("<|im_start|>");
+        var (session, spy) = BuildSession(model, tokenizer, formatter);
+        await using var _ = session;
+
+        var reply1 = await Turn(session, "first question");
+        int turn1Prompt = LastPrompt(session, reply1.Count).Length; // system + first user turn + assistant header
+        await Turn(session, "second question");
+
+        // Rewrite the first answer. Everything from there on is stale, but the
+        // system prompt, the first user turn and the assistant header before the
+        // answer are still valid cache content — the divergence is the first
+        // token of the answer.
+        var history = session.History;
+        int firstAnswerIdx = -1;
+        for (int i = 0; i < history.Count; i++)
+            if (history[i].Role == ChatRole.Agent) { firstAnswerIdx = i; break; }
+        Assert.True(firstAnswerIdx >= 0);
+        history[firstAnswerIdx].Content = "a completely different first answer";
+
+        var cacheBefore = session.Generator.CacheTokens!.ToArray();
+
+        spy.Writes.Clear();
+        var reply3 = await Turn(session, "third question");
+
+        var prompt3 = LastPrompt(session, reply3.Count);
+        int keep = CommonPrefix(cacheBefore, prompt3);
+
+        // The edit is the first answer, so the divergence is its first token: the
+        // reused prefix is turn 1's prompt (the new and old answers may share a
+        // leading token or two, never more here), and the stale tail is dropped.
+        Assert.InRange(keep, turn1Prompt, turn1Prompt + 3);
+        Assert.True(keep < cacheBefore.Length,
+            $"kept {keep} of a {cacheBefore.Length}-token cache; the edited answer should have dropped the stale tail");
+        Assert.Equal((prompt3.Length - keep) + reply3.Count, spy.Total);
+    }
+}

--- a/SharpMind.Tests/Quantization/KQuantUnpackTests.cs
+++ b/SharpMind.Tests/Quantization/KQuantUnpackTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Intrinsics.X86;
+using SharpMind.Core;
+using SharpMind.Core.Quantization;
+using Xunit;
+
+namespace SharpMind.Tests.Quantization;
+
+/// <summary>
+/// The Q4_K, Q6_K and Q5_0 vector kernels unpack packed weights straight from
+/// memory with vector shifts and masks. Q4_K reads a 32-value sub-block as one
+/// contiguous nibble run, Q6_K reassembles four interleaved groups from two
+/// nibble bytes and one high-bit byte, and Q5_0 pulls each weight's fifth bit
+/// out of a 32-bit mask with a per-lane shift. Each is easy to get subtly wrong
+/// — the wrong nibble half, the wrong bit pair, a mask applied before a shift —
+/// and the results would still look like plausible weights.
+///
+/// The existing agreement test only uses K as a multiple of the super-block, so
+/// it never sees a column that starts mid-block (K=896 puts every odd column at
+/// offset 128, which is exactly what qwen2-0.5b's ffn_down does), a column that
+/// starts off a 32 boundary (falls back to the per-weight path, which must agree
+/// too), or a partial final block. These do.
+/// </summary>
+public class KQuantUnpackTests
+{
+    public static IEnumerable<object[]> Cases()
+    {
+        foreach (var dtype in new[] { QuantDType.Q4_K, QuantDType.Q6_K, QuantDType.Q5_0 })
+            // 256/512: whole super-blocks. 896, 4864: qwen2 shapes, odd columns
+            // start at offset 128. 288/320/384: offsets 32/64/128. 8/20/137:
+            // partial blocks and columns off any alignment.
+            foreach (int k in new[] { 8, 20, 137, 256, 288, 320, 384, 512, 896, 4864 })
+                yield return new object[] { dtype, k };
+    }
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public unsafe void VectorisedTiersAgreeWithScalar(QuantDType dtype, int inFeatures)
+    {
+        if (!Avx2.IsSupported || !Fma.IsSupported) return;
+
+        const int nCols = 3;
+        const int Poison = 64;
+
+        int totalBytes = (int)QuantizationOps.GetRawTensorByteCount([inFeatures, nCols], dtype);
+        var raw = new byte[totalBytes];
+        var rng = new Random(4321 + inFeatures);
+        rng.NextBytes(raw);
+
+        // Pin every fp16 super-scale so random bytes cannot make it NaN/Inf.
+        // Q4_K: d at 0, dmin at 2 of 144. Q6_K: d at 208 of 210. Q5_0: d at 0 of 22.
+        (int blockBytes, int dOff, int minOff) = dtype switch
+        {
+            QuantDType.Q4_K => (144, 0, 2),
+            QuantDType.Q6_K => (210, 208, -1),
+            _ => (22, 0, -1),
+        };
+        for (int off = 0; off + blockBytes <= raw.Length; off += blockBytes)
+        {
+            raw[off + dOff] = 0x00; raw[off + dOff + 1] = 0x38;                       // 0.5
+            if (minOff >= 0) { raw[off + minOff] = 0x00; raw[off + minOff + 1] = 0x34; } // 0.25
+        }
+
+        // Loud padding past K: an unpack that reaches into the next block's
+        // input picks up 1e6 and blows the tolerance rather than reading zeros.
+        var input = new float[inFeatures + Poison];
+        for (int i = 0; i < inFeatures; i++) input[i] = (float)(rng.NextDouble() * 2 - 1);
+        for (int i = inFeatures; i < input.Length; i++) input[i] = 1e6f;
+
+        var scalar = QuantizationFactory.Create(HardwareTier.Scalar);
+        var avx2 = QuantizationFactory.Create(HardwareTier.AVX2);
+        var fma = QuantizationFactory.Create(HardwareTier.FMA);
+
+        fixed (float* pIn = input)
+        fixed (byte* pW = raw)
+        {
+            for (int c = 0; c < nCols; c++)
+            {
+                float expected = Dot(scalar, dtype, pIn, pW, c, inFeatures);
+                float gotAvx2 = Dot(avx2, dtype, pIn, pW, c, inFeatures);
+                float gotFma = Dot(fma, dtype, pIn, pW, c, inFeatures);
+
+                // Scalar accumulates in double; the vector kernels in float
+                // across up to 4864 terms, so the bound scales with magnitude.
+                float tol = 2e-4f * Math.Max(1f, Math.Abs(expected));
+                Assert.True(Math.Abs(expected - gotAvx2) <= tol,
+                    $"{dtype} K={inFeatures} col={c}: scalar={expected}, avx2={gotAvx2}");
+                Assert.True(Math.Abs(expected - gotFma) <= tol,
+                    $"{dtype} K={inFeatures} col={c}: scalar={expected}, fma={gotFma}");
+            }
+        }
+    }
+
+    private static unsafe float Dot(QuantizationOps ops, QuantDType dtype, float* pIn, byte* pW, int col, int k) => dtype switch
+    {
+        QuantDType.Q4_K => ops.VecDotQ4K(pIn, pW, col, k),
+        QuantDType.Q6_K => ops.VecDotQ6K(pIn, pW, col, k),
+        _ => ops.VecDotQ5_0(pIn, pW, col, k),
+    };
+}


### PR DESCRIPTION
Two independent commits on top of current `master` (ed74547): the K-quant vecdots get the same store-forwarding fix #7 gave the F16 kernel, and chat turns stop re-prefilling the whole conversation when a real template is in use. Nothing changes what the model computes — kernel output is checked against the scalar kernel, and reused-prefix replies are asserted identical to fresh-prefill replies.

Measured on the CUI's own launch path, qwen2-0.5b-instruct, Ryzen AI 7 350 (8C/16T). This laptop throttles under sustained load, so only within-run A/B numbers are quoted.

| | before | after |
|---|---|---|
| q4_k_m prefill / decode (1651-token prompt, 20 steps) | 11.3 / 7.8 tok/s | 82.5 / 32.2 tok/s — q8_0 in the same run: 95.9 / 41.7 |
| chat turn 2+ time-to-first-token, ChatML, 1651-token system prompt | 18.2 s (every turn re-prefilled) | 0.18 s |

## 1. Unpack Q4_K, Q6_K and Q5_0 weights with vector ops, not through a stack buffer

The vectorised vecdots for these formats decoded weights one at a time into a `stackalloc float[8]` and then vector-loaded that same buffer. Eight 4-byte stores followed by a 32-byte load off the same address cannot store-forward, so the loop stalled once per 8 weights on top of the scalar decode — the defect #7 removed from `VecDotF16_FMA`, still present in every K-quant kernel named `_AVX2`/`_FMA`. `VecDotQ4K_AVX2` additionally ran a full horizontal reduction inside its inner loop.

Which formats matter is decided by the file, not the name: llama.cpp only K-quantises a tensor whose row length is a multiple of 256, so in qwen2-0.5b's q4_k_m the K=896 projections (attention, gate/up) are Q5_0 and only `ffn_down` (K=4864) is Q4_K/Q6_K; a 7B with hidden 4096 is the other way round. All three are fixed the same way: widen the packed bytes straight from memory (`vpmovzxbd`), separate the fields with vector shifts and masks, convert once, apply the block scale as one FMA. Q5_0's fifth bits are one 32-bit mask per block, broadcast once, each lane shifting its own bit down (`vpsrlvd`). Sub-blocks that don't start on a 32 boundary and partial blocks keep the per-weight path, so results agree with the scalar kernel for any K, not only the aligned shapes real models use.

Before the change q4_k_m read 25% fewer bytes than q8_0 and ran 5–9× slower; decode moved 398 MB in 128 ms, nowhere near the memory wall — the time was all unpack. Top-5 logits identical before and after.

`KQuantUnpackTests` checks the AVX2 and FMA tiers against the scalar kernel for all three formats at whole super-blocks, columns starting mid-block at offset 128 (K=896, the qwen2 shape), columns off any 32 alignment (per-weight fallback), and partial final blocks, with the input padded past K so an over-read is loud. Each unpack was checked red by flipping one thing (nibble half, bit pair, mask shift). Not touched, same pattern: Q2_K, Q3_K, Q5_1, Q5_K — nothing in the local models uses them.

## 2. Reuse the KV cache across chat turns for every formatter, not just none

A chat turn only needs to feed the model the tokens that are new since the last turn; the system prompt and prior turns are already resident in the KV cache. `ChatSession` did this only when no chat formatter was set, via a hand-built `"user: …\nassistant: "` delta and a `_cacheValid`/`_cachedPromptTokens` pair guarding it. With any real template — ChatML (Qwen), Llama-3, Auto — the guard was false, the cache was reset, and the whole conversation was re-prefilled on every turn, growing with history. On a 1651-token agent system prompt that is ~18 s of prefill per turn, forever.

The delta is now computed by comparison, not by remembering what was sent. `IGenerator` exposes the ids resident in its cache (`CacheTokens`) and a `TruncateCache(length)`; `ChatSession` renders the full prompt as usual, `FeedForPrompt` finds the longest common prefix with the cache, truncates the cache to it, and feeds only the rest. Formatter-agnostic by construction, and it subsumes every case the old flag had to special-case — a compacted or evicted history, thinking stripped from an assistant turn, a reply that re-tokenises differently from how it was generated — by just moving the divergence point earlier. A cache the generator cannot vouch for (a sliding-window trim moved entries off their positions, or caches handed in pre-filled) reports `CacheTokens == null` and forces a full rebuild.

`StandardGenerator` tracks the resident ids as it prefills (around `Prefill.ForwardLastLogitsChunked`) and decodes, and drops tracking on a window trim. Speculative and Medusa don't track (they return `CacheTokens` null) and keep full-rebuild behaviour via the default `TruncateCache => ResetCache`. That removes `ChatSession`'s dependence on `CurrentGeneratedIds` for this purpose; the `_cacheValid`/`_cachedPromptTokens` bookkeeping and its five invalidation sites are gone, along with the delta-tokenisation seam hazard they carried.

Output is unchanged: greedy replies are identical whether the prefix was reused or prefilled fresh (asserted). `ChatSessionKvReuseTests` watches a spy KV cache that records the length of every write, so prefill size is measured, not inferred. It checks, for the plain and ChatML formatters: turn 2 never re-prefills the system prompt and first user turn; the ids sampled after a reused prefix equal those from a fresh prefill of the same conversation; and editing an earlier answer recomputes from exactly that answer, keeping the prefix before it. Verified red by forcing `FeedForPrompt` to always reset (3 of 5 fail; the two output-equality tests still pass because output is unchanged either way).

## Verification

- 790/790 on this branch off current `master` (ed74547).
- Independent of the companion PR (dead F32 weight per quantized inference layer); either merges alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
