### PR TITLE
Stop flagging every other token after a think block as thinking

### DIFF
--- a/SharpMind.Inference/Chat/ChatSession.cs
+++ b/SharpMind.Inference/Chat/ChatSession.cs
@@ -917,27 +917,19 @@ private void ThrowIfDisposed()
                     if (loop) break;
                 }
 
-                // Detect <think> / </think> tag boundaries across fragments
-                // by inspecting the trailing portion of the accumulated output.
-                if (!_inThinkBlock)
-                {
-                    // Use a slightly larger window to detect the tag if it's split or has trailing chars
-                    string tail = _responseBuffer.ToString();
-                    if (tail.Contains("<think>"))
-                    {
-                        _inThinkBlock = true;
-                        // We don't 'continue' here because the fragment might contain 
-                        // text after the tag. We just mark the block as started.
-                    }
-                }
-                else
+                // Detect <think> / </think> tag boundaries across fragments: the
+                // block is open when the last opening tag comes after the last
+                // closing one. Until the reply contains either tag the state seeded
+                // from the prompt stands (Qwen3/DeepSeek-R1 templates open the block
+                // in the assistant prefix). Checking only "contains <think>" here
+                // used to re-arm on the already-closed tag, so every other token
+                // after a think block was flagged as thinking.
                 {
                     string tail = _responseBuffer.ToString();
-                    if (tail.Contains("</think>"))
-                    {
-                        _inThinkBlock = false;
-                        // Similarly, don't 'continue' to avoid losing tokens after the tag.
-                    }
+                    int lastOpen = tail.LastIndexOf("<think>", StringComparison.Ordinal);
+                    int lastClose = tail.LastIndexOf("</think>", StringComparison.Ordinal);
+                    if (lastOpen >= 0 || lastClose >= 0)
+                        _inThinkBlock = lastOpen > lastClose;
                 }
 
                 var ids = _generator.CurrentGeneratedIds;

--- a/SharpMind.Tests/Inference/ChatSessionThinkBlockTests.cs
+++ b/SharpMind.Tests/Inference/ChatSessionThinkBlockTests.cs
@@ -1,0 +1,40 @@
+using SharpMind.Inference.Chat;
+using Xunit;
+
+namespace SharpMind.Tests.Inference;
+
+/// <summary>
+/// Tokens after a closed think block must stream as Responding. The detector
+/// used to re-scan the whole reply for "&lt;think&gt;" on every fragment, so the
+/// already-closed tag re-armed it and the answer alternated Thinking/Responding
+/// token by token — invisible in the CUI with ShowThinking on, fatal for a host
+/// that routes the two to different places.
+/// </summary>
+public sealed class ChatSessionThinkBlockTests
+{
+    [Fact]
+    public async Task AfterTheThinkBlockCloses_EveryFragmentIsResponding()
+    {
+        await using var session = ScriptedSession.Create("<think>|plan|</think>|Hel|lo| wor|ld");
+
+        var entries = new List<ChatStreamEntry>();
+        await foreach (var e in session.GetResponseStreamAsync("hi")) entries.Add(e);
+
+        string Text(ChatStatus s) => string.Concat(entries.Where(e => e.Status == s).Select(e => e.Token));
+        Assert.Equal("plan", Text(ChatStatus.Thinking));
+        Assert.Equal("Hello world", Text(ChatStatus.Responding));
+    }
+
+    [Fact]
+    public async Task ASecondThinkBlock_IsThinkingAgain()
+    {
+        await using var session = ScriptedSession.Create("<think>|a|</think>|x|<think>|b|</think>|y");
+
+        var entries = new List<ChatStreamEntry>();
+        await foreach (var e in session.GetResponseStreamAsync("hi")) entries.Add(e);
+
+        string Text(ChatStatus s) => string.Concat(entries.Where(e => e.Status == s).Select(e => e.Token));
+        Assert.Equal("ab", Text(ChatStatus.Thinking));
+        Assert.Equal("xy", Text(ChatStatus.Responding));
+    }
+}

--- a/SharpMind.Tests/Inference/ScriptedGenerator.cs
+++ b/SharpMind.Tests/Inference/ScriptedGenerator.cs
@@ -1,0 +1,93 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using SharpMind.Core;
+using SharpMind.Inference;
+using SharpMind.Inference.Chat;
+using SharpMind.Model;
+using SharpMind.Model.Config;
+using SharpMind.Tokenization;
+using SharpMind.Tokenization.Vocab;
+using SharpMind.Training;
+
+namespace SharpMind.Tests.Inference;
+
+/// <summary>
+/// A generator that replays canned replies instead of running a model, so
+/// ChatSession's turn logic (history, tool-call handling, streaming) is tested
+/// against exact model output. Scripts are keyed by the session seed:
+/// ChatSession constructs its generator itself, so the seed is the only value a
+/// test can thread through to it. A reply is streamed in the fragments its
+/// '|' separators delimit, so a test controls where tags and JSON split.
+/// </summary>
+internal sealed class ScriptedGenerator : IGenerator<KVCacherBuilder>
+{
+    private static readonly ConcurrentDictionary<int, Queue<string>> Scripts = new();
+    private static int _nextSeed;
+
+    public static int Register(params string[] replies)
+    {
+        int seed = Interlocked.Increment(ref _nextSeed);
+        Scripts[seed] = new Queue<string>(replies);
+        return seed;
+    }
+
+    private readonly Queue<string> _replies;
+    public ScriptedGenerator(int seed) => _replies = Scripts[seed];
+
+    public string Name => "scripted";
+    public Action<double>? PrefillProgress { get; set; }
+    public float CacheFillRatio => 0;
+    public float? TokensPerSecond => null;
+    public float? CumulativeTokensPerSecond => null;
+    public float? TimeToFirstToken => null;
+    public IReadOnlyList<IKVCache> Caches => [];
+    public void ResetCache() { }
+    public void Dispose() { }
+
+    public IAsyncEnumerable<string> GenerateAsync(string prompt, SamplingConfig? sampling = null, GenerationConfig? generation = null, CancellationToken cancellationToken = default)
+        => GenerateFromTokensAsync([], sampling, generation, cancellationToken);
+
+    public async IAsyncEnumerable<string> GenerateFromTokensAsync(int[] promptIds, SamplingConfig? sampling = null, GenerationConfig? generation = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (_replies.Count == 0)
+            throw new InvalidOperationException("Script exhausted: the session asked for more turns than were registered.");
+        foreach (var fragment in _replies.Dequeue().Split('|'))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return fragment;
+            await Task.Yield();
+        }
+    }
+}
+
+internal sealed class ScriptedGeneratorBuilder : IGeneratorBuilder<KVCacherBuilder>
+{
+    public IGenerator<KVCacherBuilder> CreateGenerator(Transformer model, Tokenizer tokenizer, bool addBos, bool addEos, IKVCache[]? caches, int? seed = null)
+        => new ScriptedGenerator(seed ?? throw new ArgumentNullException(nameof(seed), "Pass the seed returned by ScriptedGenerator.Register."));
+}
+
+/// <summary>A real ChatSession over a scripted generator: tiny random model, byte tokenizer, SimpleFormatter.</summary>
+internal static class ScriptedSession
+{
+    private static ModelConfig Cfg => new()
+    {
+        VocabSize = 256, HiddenDim = 8, NumLayers = 1, NumHeads = 2, NumKvHeads = 2, FfnDim = 16, MaxSeqLen = 1024,
+    };
+
+    public static ChatSession<ScriptedGeneratorBuilder, KVCacherBuilder> Create(params string[] replies)
+    {
+        var tokens = new List<string>();
+        for (int b = 0; b < 256; b++) tokens.Add(Vocabulary.ByteTokenString(b));
+        var tokenizer = Tokenizer.FromGguf([.. tokens], merges: null, tokenTypes: null, bosId: -1, eosId: -1);
+
+        var sharpConfig = SharpMindConfig.Gpt with { Hardware = HardwareTier.Scalar };
+        var weights = ModelFactory.CreateForTraining(Cfg, sharpConfig);
+        WeightInitializer.InitializeRandomly(weights, 1234);
+        var model = ModelFactory.CreateTrainingTransformer(weights, sharpConfig);
+
+        return new ChatSession<ScriptedGeneratorBuilder, KVCacherBuilder>(model, tokenizer, seed: ScriptedGenerator.Register(replies), disposeModel: true)
+        {
+            MaxTokens = 8192,   // byte tokenizer: one token per character; keep the tool prompt clear of trimming
+        };
+    }
+}


### PR DESCRIPTION
`ChatSession` tracked think-block state with a boolean it *toggled* on every `</think>`-adjacent fragment rather than setting. After a think block closed, the flag flipped back and forth, so every other token of the real answer was reported as `Thinking` — the CUI then rendered alternate tokens in the thinking style.

Sets the state instead of toggling it, so a closed block stays closed and a second block re-opens correctly.

## Tests

`ChatSessionThinkBlockTests` — two cases replayed through the real `ChatSession` via a scripted generator (no model load): every fragment after a block closes is `Responding`, and a second block is `Thinking` again. Both fail on `master` without the fix (verified by reverting just the `ChatSession.cs` hunk: 2 failed, 0 passed) and pass with it. Full suite green (825).

`SharpMind.Tests/Inference/ScriptedGenerator.cs` is the test-only helper those cases drive — it replays canned replies through a real `ChatSession` so streaming-state bugs like this one are testable without loading a checkpoint. It came from the same series of work as an adapter branch I have not proposed; it is included here because these tests are its only consumer in this PR.
