### PR TITLE
Store the LM head verbatim [vocab, in]; stop transposing it on load and mis-sizing it from our own exports

### DIFF
--- a/SharpMind.Model/Format/GgufLoader.cs
+++ b/SharpMind.Model/Format/GgufLoader.cs
@@ -653,24 +653,12 @@ public sealed class GgufLoader(QuantizationOps qOps, string path, ModelConfig co
             if (target != null)
             {
                 target.Data.Clear();
-                if (target == weights.LmHeadWeight && info.Shape.Length == 2)
-                {
-                    // The head's data is [in, vocab] row-major in both file flavors (the
-                    // SMM exporter transposes on write, matching foreign GGUFs) — but the
-                    // header order differs: foreign files declare [in, vocab], our own
-                    // SMM->GGUF export declares [vocab, in]. Pick the dims by role, not
-                    // position, or the transpose builds a scrambled head.
-                    int d0 = (int)info.Shape[0], d1 = (int)info.Shape[1];
-                    bool vocabFirst = d0 == _config.VocabSize && d1 != _config.VocabSize;
-                    int ggufIn = vocabFirst ? d1 : d0, ggufOut = vocabFirst ? d0 : d1;
-                    for (int i = 0; i < ggufIn; i++)
-                        for (int j = 0; j < ggufOut; j++)
-                            target.Data[j * ggufIn + i] = buffer[i * ggufOut + j];
-                }
-                else
-                {
-                    buffer.AsSpan(0, count).CopyTo(target.Data);
-                }
+                // The head's data is [vocab, in] row-major in every real file — foreign
+                // GGUFs store it exactly like the embedding (only the header order
+                // differs: [in, vocab]), and SmmTrainingExporter now writes it verbatim
+                // too. The transpose this branch used to do scrambled every float head;
+                // it went unnoticed because serving consumes the raw bytes instead.
+                buffer.AsSpan(0, count).CopyTo(target.Data);
             }
             else if (block != null)
             {

--- a/SharpMind.Model/Format/GgufLoader.cs
+++ b/SharpMind.Model/Format/GgufLoader.cs
@@ -537,7 +537,13 @@ public sealed class GgufLoader(QuantizationOps qOps, string path, ModelConfig co
         // the LM head tensor is never allocated and the weight data is skipped.
         if (!info.Name.Contains("blk.") && info.Name.Contains("output.weight") && weights.LmHeadWeight == null)
         {
+            // Canonical GGUFs store output.weight as [input, vocab]; our own SMM->GGUF
+            // export writes the tensor's in-memory [vocab, input] order (same bytes either
+            // way — the input dim is contiguous in both). The input dim is whichever shape
+            // entry is not the vocab size; trusting Shape[0] blindly built a [vocab, vocab]
+            // head for exported fine-tunes, which overflows int at real vocab sizes.
             long ggufIn = info.Shape[0];
+            if (info.Shape.Length > 1 && ggufIn == _config.VocabSize) ggufIn = info.Shape[1];
             int lmRows = TensorLoadHelper.CheckedInt(_config.VocabSize, "VocabSize for LmHead");
             int lmCols = TensorLoadHelper.CheckedInt(ggufIn, "LmHead input dim");
             weights.SetLmHead(new Tensor<float>(lmRows, lmCols));
@@ -649,7 +655,14 @@ public sealed class GgufLoader(QuantizationOps qOps, string path, ModelConfig co
                 target.Data.Clear();
                 if (target == weights.LmHeadWeight && info.Shape.Length == 2)
                 {
-                    int ggufIn = (int)info.Shape[0], ggufOut = (int)info.Shape[1];
+                    // The head's data is [in, vocab] row-major in both file flavors (the
+                    // SMM exporter transposes on write, matching foreign GGUFs) — but the
+                    // header order differs: foreign files declare [in, vocab], our own
+                    // SMM->GGUF export declares [vocab, in]. Pick the dims by role, not
+                    // position, or the transpose builds a scrambled head.
+                    int d0 = (int)info.Shape[0], d1 = (int)info.Shape[1];
+                    bool vocabFirst = d0 == _config.VocabSize && d1 != _config.VocabSize;
+                    int ggufIn = vocabFirst ? d1 : d0, ggufOut = vocabFirst ? d0 : d1;
                     for (int i = 0; i < ggufIn; i++)
                         for (int j = 0; j < ggufOut; j++)
                             target.Data[j * ggufIn + i] = buffer[i * ggufOut + j];

--- a/SharpMind.Model/Format/SmmLoader.cs
+++ b/SharpMind.Model/Format/SmmLoader.cs
@@ -278,7 +278,10 @@ public sealed class SmmLoader(QuantizationOps qOps, string path, ModelConfig con
         // GgufLoader for the rationale).
         if (!entry.Name.Contains("blk.") && entry.Name.Contains("output.weight") && weights.LmHeadWeight == null)
         {
+            // The input dim is whichever shape entry is not the vocab size — our own
+            // exports declare [vocab, in], canonical GGUF-derived files [in, vocab].
             long ggufIn = entry.Shape[0];
+            if (entry.Shape.Length > 1 && ggufIn == _config.VocabSize) ggufIn = entry.Shape[1];
             int lmRows = TensorLoadHelper.CheckedInt(_config.VocabSize, "VocabSize for LmHead");
             int lmCols = TensorLoadHelper.CheckedInt(ggufIn, "LmHead input dim");
             weights.SetLmHead(new Tensor<float>(lmRows, lmCols));
@@ -347,17 +350,9 @@ public sealed class SmmLoader(QuantizationOps qOps, string path, ModelConfig con
             if (target != null)
             {
                 target.Data.Clear();
-                if (target == weights.LmHeadWeight && entry.Shape.Length == 2)
-                {
-                    int ggufIn = entry.Shape[0], ggufOut = entry.Shape[1];
-                    for (int i = 0; i < ggufIn; i++)
-                        for (int j = 0; j < ggufOut; j++)
-                            target.Data[j * ggufIn + i] = buffer[i * ggufOut + j];
-                }
-                else
-                {
-                    buffer.AsSpan(0, count).CopyTo(target.Data);
-                }
+                // Head data is [vocab, in] row-major in every file (see GgufLoader's
+                // matching comment) — verbatim copy, same as the embedding.
+                buffer.AsSpan(0, count).CopyTo(target.Data);
             }
             else if (block != null)
             {

--- a/SharpMind.Model/Format/SmmTrainingExporter.cs
+++ b/SharpMind.Model/Format/SmmTrainingExporter.cs
@@ -70,7 +70,7 @@ public static class SmmTrainingExporter
         if (weights.PositionEmbedding is not null)
             yield return Tensor2D("position_embd.weight", weights.PositionEmbedding, transpose: false);
         if (weights.LmHeadWeight is not null)
-            yield return Tensor2D("output.weight", weights.LmHeadWeight);
+            yield return Tensor2D("output.weight", weights.LmHeadWeight, transpose: false);
         yield return Tensor1D("output_norm.weight", weights.FinalNormWeight);
         if (weights.FinalNormBias is not null)
             yield return Tensor1D("output_norm.bias", weights.FinalNormBias);

--- a/SharpMind.Tests/ModelFormat/SmmExportLoadTests.cs
+++ b/SharpMind.Tests/ModelFormat/SmmExportLoadTests.cs
@@ -275,6 +275,32 @@ public class SmmExportLoadTests : IDisposable
     }
 
     [Fact]
+    public void GgufConversion_UntiedLmHead_ReloadsWithCorrectShape()
+    {
+        // CARD-1404: a fine-tuned model with a separate LM head (Qwen2.5-1.5B) exported
+        // SMM->GGUF and failed to reload. GgufLoader sizes the head from Shape[0] because
+        // canonical GGUFs put the input dim first — but our own converter writes the
+        // tensor's in-memory [vocab, hidden] order, so the head came back [vocab, vocab]:
+        // an int overflow at real vocab sizes, a silently wrong shape here.
+        using var fixture = TrainFixture();
+        int vocab = fixture.Config.VocabSize, hidden = fixture.Config.HiddenDim;
+        var head = new Tensor<float>(vocab, hidden);
+        for (int i = 0; i < head.Data.Length; i++) head.Data[i] = i * 1e-3f;
+        fixture.Weights.SetLmHead(head); // fixture.Weights owns and disposes it
+
+        string smmPath = Path.Combine(_temp.Path, "untied.smm");
+        SmmTrainingExporter.Export(fixture.Weights, fixture.Tokenizer, smmPath, new SmmWriteOptions { Source = "training" });
+        string ggufPath = Path.Combine(_temp.Path, "untied.gguf");
+        SmmToGufConverter.Convert(smmPath, ggufPath);
+
+        using var reloaded = LoadWeightsFrom(ggufPath, fixture.Config, out _);
+        Assert.NotNull(reloaded.LmHeadWeight);
+        Assert.Equal(vocab, reloaded.LmHeadWeight!.Shape.Rows);
+        Assert.Equal(hidden, reloaded.LmHeadWeight.Shape.Cols);
+        AssertTensorClose(head, reloaded.LmHeadWeight, 1e-6f, "gguf.output");
+    }
+
+    [Fact]
     public void GgufConversion_CancelledBeforeStart_WritesNothing()
     {
         string ggufPath = Path.Combine(_temp.Path, "tiny.gguf");

--- a/SharpMind.Tests/ModelFormat/SmmExportLoadTests.cs
+++ b/SharpMind.Tests/ModelFormat/SmmExportLoadTests.cs
@@ -301,6 +301,56 @@ public class SmmExportLoadTests : IDisposable
     }
 
     [Fact]
+    public void GgufLoad_CanonicalLmHeadHeader_ReloadsVerbatim()
+    {
+        // Canonical GGUFs (llama.cpp converters) declare output.weight as [hidden, vocab]
+        // while storing exactly the same [vocab, hidden] row-major bytes as the embedding.
+        // The loader used to "correct" that header order with a transpose of the data,
+        // which scrambled every float head. Build a canonical-order file by swapping the
+        // two dims in the header of our own export — the data bytes are identical either
+        // way — and check the head comes back untouched.
+        using var fixture = TrainFixture();
+        int vocab = fixture.Config.VocabSize, hidden = fixture.Config.HiddenDim;
+        Assert.NotEqual(vocab, hidden); // a transpose would be invisible on a square head
+        var head = new Tensor<float>(vocab, hidden);
+        for (int i = 0; i < head.Data.Length; i++) head.Data[i] = i * 1e-3f;
+        fixture.Weights.SetLmHead(head);
+
+        string smmPath = Path.Combine(_temp.Path, "canonical.smm");
+        SmmTrainingExporter.Export(fixture.Weights, fixture.Tokenizer, smmPath, new SmmWriteOptions { Source = "training" });
+        string ggufPath = Path.Combine(_temp.Path, "canonical.gguf");
+        SmmToGufConverter.Convert(smmPath, ggufPath);
+        SwapHeaderDims(ggufPath, "output.weight");
+
+        using var reloaded = LoadWeightsFrom(ggufPath, fixture.Config, out _);
+        Assert.NotNull(reloaded.LmHeadWeight);
+        Assert.Equal(vocab, reloaded.LmHeadWeight!.Shape.Rows);
+        Assert.Equal(hidden, reloaded.LmHeadWeight.Shape.Cols);
+        AssertTensorClose(head, reloaded.LmHeadWeight, 1e-6f, "gguf.output(canonical)");
+    }
+
+    /// <summary>
+    /// Swaps the two dims of a 2D tensor's header entry in a GGUF file, leaving the data
+    /// untouched. Tensor info layout: u64 name length, name bytes, u32 n_dims, u64 dims[].
+    /// The length-prefixed name is unique (blk.N.attn_output.weight has a different prefix).
+    /// </summary>
+    private static void SwapHeaderDims(string ggufPath, string tensorName)
+    {
+        byte[] file = File.ReadAllBytes(ggufPath);
+        byte[] nameBytes = Encoding.UTF8.GetBytes(tensorName);
+        byte[] needle = [.. BitConverter.GetBytes((ulong)nameBytes.Length), .. nameBytes];
+        int at = file.AsSpan().IndexOf(needle);
+        Assert.True(at >= 0, $"{tensorName} not found in GGUF header");
+        int dimsAt = at + needle.Length;
+        Assert.Equal(2u, BitConverter.ToUInt32(file, dimsAt));
+        dimsAt += 4;
+        ulong d0 = BitConverter.ToUInt64(file, dimsAt), d1 = BitConverter.ToUInt64(file, dimsAt + 8);
+        BitConverter.GetBytes(d1).CopyTo(file, dimsAt);
+        BitConverter.GetBytes(d0).CopyTo(file, dimsAt + 8);
+        File.WriteAllBytes(ggufPath, file);
+    }
+
+    [Fact]
     public void GgufConversion_CancelledBeforeStart_WritesNothing()
     {
         string ggufPath = Path.Combine(_temp.Path, "tiny.gguf");


### PR DESCRIPTION
## The bug

`output.weight` (the untied LM head) had three conventions fighting each other:

- **`SmmTrainingExporter`** wrote the head *transposed* on disk while recording the *untransposed* shape `[vocab, in]`.
- **`GgufLoader` / `SmmLoader`** sized the head from `Shape[0]`, assuming the canonical GGUF order `[in, vocab]`. For our own exports that makes `Shape[0] == vocab`, so the head came back `[vocab, vocab]` — an int overflow at real vocab sizes (Qwen2.5-1.5B: 151936² floats).
- Both loaders then "corrected" the header order with a dequant-path transpose of the data. But canonical GGUFs already store the head as `[vocab, in]` row-major — exactly like the embedding, only the header lists dims innermost-first. The transpose scrambled every float head it touched.

It stayed latent for a long time because serving reads the raw bytes through the quantized path, and tied models (most small ones) never export a head at all. The first untied fine-tune export shipped a permuted head; the two permutations cancel on row 0, which is why spot checks looked fine.

## The fix

One convention: the head is stored verbatim `[vocab, in]` row-major in every format, like the embedding.

- exporter writes `output.weight` untransposed (`transpose: false`)
- both loaders copy the head verbatim, no transpose branch
- the input dim is whichever shape entry is **not** the vocab size — correct for our own exports (`[vocab, in]`) and for canonical GGUFs (`[in, vocab]`) alike

Net: 3 engine files, +13 / −30 lines.

## Tests

- `GgufConversion_UntiedLmHead_ReloadsWithCorrectShape` — untied head round-trips SMM → GGUF → load with the right shape and values.
- `GgufLoad_CanonicalLmHeadHeader_ReloadsVerbatim` — swaps the two header dims of our export (bytes unchanged — that is what a llama.cpp-converted file looks like) and checks the head reloads untouched.

Both fail against the old loader. Full suite: 894/894 green.

## Compatibility

Files already exported with the old exporter carry a permuted head *on disk* — the loader cannot repair those; re-export from the SMM/training checkpoint. Canonical GGUFs and tied models are unaffected (they load correctly for the first time / as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
