### PR TITLE
Await the producer when a data-loading enumeration is abandoned early

### DIFF
--- a/SharpMind.Data/DataLoader.cs
+++ b/SharpMind.Data/DataLoader.cs
@@ -64,6 +64,11 @@ public sealed class DataLoader
             SingleWriter = true
         });
 
+        // Linked so that abandoning the enumeration (e.g. the caller breaks out of
+        // its `await foreach`) can cancel the producer even when the caller's own
+        // token is never cancelled — see the finally block below.
+        using var producerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
         // Background producer: feeds the channel from the batcher, re-enumerating
         // the pipeline (epoch style) until the batch budget is satisfied.
         var producer = Task.Run(async () =>
@@ -76,11 +81,11 @@ public sealed class DataLoader
                 {
                     firstPass = false;
                     int passBatches = 0;
-                    await foreach (var batch in _batcher.BatchAsync(_pipeline.ReadAsync(cancellationToken), _tokenise, cancellationToken))
+                    await foreach (var batch in _batcher.BatchAsync(_pipeline.ReadAsync(producerCts.Token), _tokenise, producerCts.Token))
                     {
                         if (budget is { } remaining && produced >= remaining)
                             break;
-                        await channel.Writer.WriteAsync(batch, cancellationToken);
+                        await channel.Writer.WriteAsync(batch, producerCts.Token);
                         produced++;
                         passBatches++;
                     }
@@ -99,19 +104,39 @@ public sealed class DataLoader
             {
                 channel.Writer.TryComplete();
             }
-        }, cancellationToken);
+        }, producerCts.Token);
 
-        // Consumer: reads from the channel
-        while (await channel.Reader.WaitToReadAsync(cancellationToken))
+        try
         {
-            while (channel.Reader.TryRead(out var batch))
+            // Consumer: reads from the channel
+            while (await channel.Reader.WaitToReadAsync(cancellationToken))
             {
-                yield return batch;
+                while (channel.Reader.TryRead(out var batch))
+                {
+                    yield return batch;
+                }
             }
         }
+        finally
+        {
+            // Runs on every exit path — normal completion, early disposal from a
+            // caller breaking out of its `await foreach`, or an exception — not
+            // just the happy path. Without this, an abandoned producer keeps
+            // running in the background, still holding the corpus source open.
+            producerCts.Cancel();
+            try
+            {
+                await producer;
+            }
+            catch (OperationCanceledException) { }
 
-        // Ensure producer is cleaned up
-        await producer;
+            // The producer may have written batches the consumer never read (early
+            // break). Drain and dispose them now rather than leaving their
+            // NativeMemory-backed tensors alive until finalisation. Safe only after
+            // awaiting the producer above — nothing can write to the channel anymore.
+            while (channel.Reader.TryRead(out var abandoned))
+                abandoned.Dispose();
+        }
     }
 
     /// <summary>

--- a/SharpMind.Tests/Data/DataLoaderIntegrationTests.cs
+++ b/SharpMind.Tests/Data/DataLoaderIntegrationTests.cs
@@ -109,6 +109,37 @@ public sealed class DataLoaderIntegrationTests : IDisposable
     }
 
     [Fact]
+    public async Task LoadAsync_AbandonedEarly_ReleasesTheCorpusFile()
+    {
+        // Windows-only guard: File.Delete happily unlinks an open file on Linux, so
+        // Assert.Null below passes there regardless of whether the file is actually
+        // released — don't "fix" this test off a green ubuntu-latest run (ci.yml runs
+        // both ubuntu-latest and windows-latest).
+        // Far more lines than the prefetch buffer + what we consume below, so the
+        // background producer is still mid-file (StreamReader open) and blocked
+        // writing to a full channel at the moment the consumer walks away.
+        string path = _dir.Write("corpus.txt",
+            string.Join('\n', Enumerable.Range(0, 500).Select(i => $"word{i} foo bar")));
+
+        var pipeline = CleaningPipeline.From(new TextFileSource(path));
+        var loader   = new DataLoader(pipeline, Tokenise,
+                          new PackingBatcher(batchSize: 1, maxSeqLen: 16),
+                          prefetchBuffer: 1);
+
+        int consumed = 0;
+        await foreach (var batch in loader.LoadAsync())
+        {
+            batch.Dispose();
+            if (++consumed >= 2) break;
+        }
+
+        // Breaking out of the enumeration must not abandon the producer while it
+        // still holds the corpus file open.
+        var ex = Record.Exception(() => File.Delete(path));
+        Assert.Null(ex);
+    }
+
+    [Fact]
     public async Task EndToEnd_Jsonl_SafetyStages()
     {
         string path = _dir.Write("data.jsonl",


### PR DESCRIPTION
`DataLoader.LoadAsync` is an async iterator. It starts a producer task that writes into a channel, yields batches from that channel, and then awaits the producer to clean it up — but that `await producer` sits in straight-line code *after* the consumer loop:

```csharp
while (await channel.Reader.WaitToReadAsync(cancellationToken))
{
    while (channel.Reader.TryRead(out var batch))
        yield return batch;
}

// Ensure producer is cleaned up
await producer;
```

Breaking out of an `await foreach` disposes the enumerator, which runs `finally` blocks but never resumes into straight-line code after the loop. So that await only happens when the enumeration runs to completion.

`TrainLoop.RunAsync` breaks out early by design:

```csharp
if (step >= _config.TotalSteps) break;
```

That means **every training run that reaches its step budget** abandons the producer while it is still holding the corpus source open. Because the caller's token is typically never cancelled on that path, the producer stays parked on a bounded-channel `WriteAsync` for the lifetime of the process, and on Windows the corpus file cannot be deleted or moved until the process exits.

### The fix

Link the caller's token to an internal `CancellationTokenSource`, give that to the producer, and move the await into a `finally` so it runs on every exit path — normal completion, early disposal, or exception. Any batches the consumer never read are drained and disposed there too, rather than leaving their unmanaged buffers to finalisation.

The producer already catches `OperationCanceledException`, so `await producer` completes rather than faults.

### Evidence

`LoadAsync_AbandonedEarly_ReleasesTheCorpusFile` consumes one batch, breaks, and asserts the corpus file can then be deleted.

- Against `master`: fails with `IOException` — "The process cannot access the file ... because it is being used by another process".
- With the fix: passes.

Full suite on this branch: **927/927**.

One note on the test: it is a Windows-specific guard, and it says so in a comment. On Linux `File.Delete` will happily unlink a file that is still open, so the assertion cannot fail there — it is still worth running on both legs, but Windows is where it has teeth.

Found while working on the accelerator-plugin groundwork from #13 — a new test that broke out of an enumeration early exposed it. Sending it separately since it is unrelated to that seam and stands on its own.
