### PR TITLE
Keep block activations alive until the block context is disposed

### DIFF
--- a/SharpMind.Tests/Training/BackpropEngineTests.cs
+++ b/SharpMind.Tests/Training/BackpropEngineTests.cs
@@ -196,6 +196,64 @@ public sealed class BackpropEngineTests
         Assert.True(losses[^1] < losses[0], $"backprop MoE loss did not descend: {losses[0]:F4} → {losses[^1]:F4}");
     }
 
+    [Fact]
+    public unsafe void ForwardAndRecord_KeepsBlockContextBuffersDistinctFromLaterAllocations()
+    {
+        // Regression test for a premature-dispose bug in ForwardBlock: after
+        // ForwardAttention/ForwardFfn store their output tensor into BlockContext
+        // (bc.AttnProjOut / bc.FfnOut) for backward to read later, ForwardBlock
+        // immediately Dispose()s that SAME tensor object -- returning its buffer to
+        // NativeBufferPool while BlockContext still holds what looks like a live
+        // reference.
+        //
+        // This is not a rare concurrency race: NativeBufferPool buckets by
+        // power-of-two element count, and the very next same-shape allocation
+        // after each early dispose -- block.Norm2.ForwardWithState(x) right after
+        // attnProj.Dispose(), and _model.FinalNorm.ForwardWithState(x) right after
+        // ffnOut.Dispose() -- pops that exact freed buffer straight back off the
+        // free list and hands it out, deterministically, on every single-threaded
+        // run, with no other thread involved. Verified empirically: on unfixed
+        // code, bc.FfnOut.DataPtr == ctx.FinalNormOut.DataPtr and
+        // bc.AttnProjOut.DataPtr == bc.Norm2Out.DataPtr -- BlockContext's fields
+        // silently alias unrelated later tensors instead of holding the block's
+        // own activations. Only the MoE FFN's backward reads bc.FfnOut back
+        // (Σ w·dW = dOut·out in BackpropEngine's MoE FfnBackward case), so that's
+        // where the aliasing turns into a silently wrong gradient.
+        var modelConfig = SmallMoEConfig;
+        var sharpConfig = SharpMindConfig.ForModel(modelConfig.NumHeads, modelConfig.NumKvHeads, "mixtral");
+        var (model, parameters, config) = Fixture(modelConfig, sharpConfig);
+        using var _m = model;
+
+        var mapping = GradientMappingFactory.Create(config);
+        using var engine = new BackpropEngine(model, mapping, parameters, config);
+
+        using var tokenIds = DeterministicBatch(out _);
+        using var ctx = new ForwardContext();
+        var logits = engine.ForwardAndRecord(ctx, tokenIds);
+        using var logitsFlat = logits.Reshape(Batch * Seq, modelConfig.VocabSize);
+
+        var bc = ctx.Blocks[0];
+        Assert.NotNull(bc.FfnOut);
+        Assert.NotNull(bc.AttnProjOut);
+        Assert.NotNull(bc.Norm2Out);
+        Assert.NotNull(ctx.FinalNormOut);
+
+        IntPtr ffnOutPtr = (IntPtr)bc.FfnOut!.DataPtr;
+        IntPtr finalNormOutPtr = (IntPtr)ctx.FinalNormOut!.DataPtr;
+        Assert.True(ffnOutPtr != finalNormOutPtr,
+            "bc.FfnOut aliases ctx.FinalNormOut's buffer: ForwardBlock's early ffnOut.Dispose() " +
+            "returned the buffer to NativeBufferPool, and the final RMSNorm's same-shape output " +
+            "immediately rented it back -- backward's MoE router-weight gradient " +
+            "(Σ w·dW = dOut·out) would silently read FinalNormOut's data instead of the real FFN output.");
+
+        IntPtr attnProjPtr = (IntPtr)bc.AttnProjOut!.DataPtr;
+        IntPtr norm2OutPtr = (IntPtr)bc.Norm2Out!.DataPtr;
+        Assert.True(attnProjPtr != norm2OutPtr,
+            "bc.AttnProjOut aliases bc.Norm2Out's buffer: ForwardBlock's early attnProj.Dispose() " +
+            "returned the buffer to NativeBufferPool, and norm2's same-shape output immediately " +
+            "rented it back -- the same premature-dispose bug as bc.FfnOut, one line earlier.");
+    }
+
     // ── helpers ─────────────────────────────────────────────────────────────
 
     private static List<Parameter> SelectTargets(Transformer model)

--- a/SharpMind.Training/Autograd/BackpropEngine.cs
+++ b/SharpMind.Training/Autograd/BackpropEngine.cs
@@ -221,7 +221,6 @@ public sealed class BackpropEngine : IDisposable
 
         var attnProj = ForwardAttention(norm1Out, block.Attention, bc);
         x.AddInPlace(attnProj);
-        attnProj.Dispose();
 
         var (norm2Out, norm2State) = block.Norm2.ForwardWithState(x);
         bc.Norm2Out = norm2Out;
@@ -229,7 +228,6 @@ public sealed class BackpropEngine : IDisposable
 
         var ffnOut = ForwardFfn(norm2Out, block.Ffn, bc);
         x.AddInPlace(ffnOut);
-        ffnOut.Dispose();
 
         return x;
     }


### PR DESCRIPTION
`ForwardBlock` disposes the two tensors it has just handed to the `BlockContext`, which returns their buffers to `NativeBufferPool` while the context still holds them as live state for backward.

```csharp
var attnProj = ForwardAttention(norm1Out, block.Attention, bc);  // sets bc.AttnProjOut = attnProj
x.AddInPlace(attnProj);
attnProj.Dispose();                                              // buffer goes back to the pool

var ffnOut = ForwardFfn(norm2Out, block.Ffn, bc);                // sets bc.FfnOut
x.AddInPlace(ffnOut);
ffnOut.Dispose();                                                // same
```

Every other `bc.X = y` field in that method (`Norm1Out`, `Norm2Out`, `Q`/`K`/`V`) is left alone and disposed once, later, by `BlockContext.Dispose()`. These two are the only ones that don't follow that pattern.

`Tensor<T>.Dispose()` is idempotent, so the second disposal in `BlockContext.Dispose()` is a harmless no-op — there's no double-free. The problem is the early return to the pool.

### It aliases deterministically, not occasionally

The pool buckets by power-of-two element count and hands back the most recently returned buffer, so the very next same-shape `[Batch, Seq, HiddenDim]` allocation gets the buffer straight back:

- `Norm2.ForwardWithState(x)` runs immediately after `attnProj.Dispose()` → `bc.AttnProjOut.DataPtr == bc.Norm2Out.DataPtr`
- `FinalNorm.ForwardWithState(x)` runs immediately after `ffnOut.Dispose()` → `bc.FfnOut.DataPtr == ctx.FinalNormOut.DataPtr`

So after a forward pass the context's stored activations alias unrelated tensors' data on every run, single-threaded, no concurrency involved.

### What reads it back

MoE is the only FFN kind whose backward reads either field again — the router-weight gradient needs the FFN output:

```csharp
using var outFlat = bc.FfnOut!.Reshape(rows, H);   // for Σ w·dW = dOut·out
```

By then `bc.FfnOut` is the final RMSNorm's output, so the router-weight gradient is computed from the wrong tensor. Dense and Gated FFN have the same premature dispose but never read those fields back, so nothing observable happens there.

`Backward_MoEGradientsMatchFiniteDifference` doesn't catch it: between the 2e-2 tolerance, the 24-element spot check and the routing-flip skip, it's not tight enough to see this particular corruption.

### The fix

Delete the two `Dispose()` calls. `BlockContext.Dispose()` already disposes both fields exactly once.

Nothing leaks as a result: `ForwardAttention` has a single return path with `bc.AttnProjOut = attnProj` immediately before it, and all three `ForwardFfn` cases (Dense, Gated, MoE) assign `bc.FfnOut` before returning, with the `default` case throwing.

### Test

`ForwardAndRecord_KeepsBlockContextBuffersDistinctFromLaterAllocations` asserts the aliasing directly — after `ForwardAndRecord` on a small MoE config, `bc.FfnOut` must not share a buffer with `ctx.FinalNormOut`, and `bc.AttnProjOut` must not share one with `bc.Norm2Out`.

Against `master` it fails on the first run:

```
bc.FfnOut aliases ctx.FinalNormOut's buffer: ForwardBlock's early ffnOut.Dispose() returned the
buffer to NativeBufferPool, and the final RMSNorm's same-shape output immediately rented it back
```

With the fix it passes. Full suite on this branch: **927/927**.

A gradient-value test was tried first and rejected — it passed against unfixed code, because the corruption depends on which buffer the pool hands back. Asserting the buffer identity tests the actual mechanism rather than a downstream symptom that may or may not surface.

Found while investigating an unrelated non-determinism in the training suite.
