### PR TITLE
Sanitise every block scale in the quantization agreement fixture

### DIFF
--- a/SharpMind.Tests/Quantization/QuantizationAgreementTests.cs
+++ b/SharpMind.Tests/Quantization/QuantizationAgreementTests.cs
@@ -45,7 +45,11 @@ public class QuantizationAgreementTests
     private static int GetBlockBytes(QuantDType dtype)
     {
         int blockSize = GetBlockSize(dtype);
-        return (int)QuantizationOps.GetRawTensorByteCount([blockSize, 1], dtype);
+        // One block is blockSize elements along the LAST axis. The 32-element formats size
+        // themselves from that axis, so [blockSize, 1] asks for blockSize rows of one padded
+        // block each - 32x the real stride, which left SanitizeScaleValues pinning one scale
+        // in every 32 blocks. The 256-element K-quants divide total elements and were unaffected.
+        return (int)QuantizationOps.GetRawTensorByteCount([1, blockSize], dtype);
     }
 
     private static byte[] GenerateRawData(QuantDType dtype, int K, int N, int seed)
@@ -260,6 +264,41 @@ public class QuantizationAgreementTests
             if (exp <= 0) return (ushort)sign;
             if (exp >= 31) return (ushort)(sign | 0x7C00);
             return (ushort)(sign | ((uint)exp << 10) | (mantissa >> 13));
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(UniqueDtypes))]
+    public unsafe void GenerateRawData_LeavesNoNonFiniteWeights(QuantDType dtype)
+    {
+        // The fixture weights are random bytes, so SanitizeScaleValues has to overwrite
+        // every block's scale field or a block can carry an fp16 Inf/NaN (any scale whose
+        // five exponent bits are all set - about 3% of random draws). That poisons a dot
+        // product silently: a NaN difference loses every '>' comparison, so a tier that
+        // disagreed would still be reported as agreeing.
+        var tiers = GetAvailableTiers();
+        if (tiers.Count < 2) return;
+
+        int blockSize = GetBlockSize(dtype);
+        int K = blockSize * 8;
+        int N = blockSize * 4;
+        if (dtype is QuantDType.F32 or QuantDType.F16) { K = 256; N = 128; }
+
+        var rawData = GenerateRawData(dtype, K, N, 42);
+        var input = new float[K];
+        var rng = new Random(42);
+        for (int i = 0; i < K; i++) input[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        var ops = CreateSerialOps(tiers[0].tier);
+        fixed (float* pIn = input)
+        fixed (byte* pRaw = rawData)
+        {
+            for (int col = 0; col < N; col++)
+            {
+                float v = ops.VecDotFor(dtype, pIn, pRaw, col, K);
+                Assert.True(float.IsFinite(v),
+                    $"[{dtype}] column {col} dotted to {v} - a block scale was left unsanitised.");
+            }
         }
     }
 }


### PR DESCRIPTION
`QuantizationAgreementTests` generates its weight fixtures from random bytes and then calls `SanitizeScaleValues` to overwrite each block's scale field, so that a random draw cannot produce an Inf or NaN scale. It has only been overwriting one scale in every 32.

### Cause

`GetBlockBytes` asks for the size of a single block like this:

```csharp
return (int)QuantizationOps.GetRawTensorByteCount([blockSize, 1], dtype);
```

`GetBlockQuantByteCount` sizes block-quantised tensors along the **last** axis:

```csharp
return outerElements * ((lastDim + blockSize - 1) / blockSize) * blockBytes;
```

So `[32, 1]` reads as 32 rows of one element, each padded to a whole block — `32 × 1 × 34 = 1088` bytes for Q8_0, where one block is 34. `SanitizeScaleValues` then strides the buffer by 1088 and pins 32 of the 1024 blocks in a 256×128 fixture. The remaining 97% keep their random bytes, and any fp16 whose five exponent bits are all set is an Inf or NaN — roughly 3% of random draws.

### Why it matters beyond tidiness

The comparison in these tests is:

```csharp
double err = Math.Abs(results[i] - reference[i]);
if (err > maxErr) maxErr = err;
```

`NaN > maxErr` is false, so a poisoned element is silently skipped rather than reported. A tier that genuinely disagreed on one of those elements would still pass. The fixture was quietly weakening the assertion it exists to support.

### Scope

Only the 32-element formats took their stride from the last axis and were affected: **Q8_0, Q8_1, Q4_0, Q4_1, Q5_0, Q5_1, IQ4_NL**. The 256-element K-quants compute from total elements, which is independent of axis order, so their stride was already correct.

### Fix

`[blockSize, 1]` → `[1, blockSize]`, one block along the last axis.

### Proof

The new test `GenerateRawData_LeavesNoNonFiniteWeights` dots every column of the generated fixture and asserts the result is finite.

Before the fix — red on exactly the seven affected formats, and nothing else:

```
Failed ... (dtype: Q8_0)    Failed ... (dtype: Q8_1)
Failed ... (dtype: Q4_0)    Failed ... (dtype: Q4_1)
Failed ... (dtype: Q5_0)    Failed ... (dtype: Q5_1)
Failed ... (dtype: IQ4_NL)
Failed! - Failed: 7, Passed: 8, Total: 15
```

After the fix, the whole class is green, and correcting the fixture exposed **no** hidden tier disagreements:

```
Passed! - Failed: 0, Passed: 45, Total: 45
```

Full suite: `Passed! - Failed: 0, Passed: 968, Total: 968`.

Test-only change; no production code is touched.
