### PR TITLE
Publish the activation factory's last-hit slot as one atomic pair

### DIFF
--- a/SharpMind.Core/Activations/ActivationFactory.cs
+++ b/SharpMind.Core/Activations/ActivationFactory.cs
@@ -30,11 +30,15 @@ public static class ActivationFactory
 {
     private static readonly ConcurrentDictionary<int, ActivationOps> _opsCache = [];
 
-    // Fast last-hit slot: skips the dictionary probe when the same mapping
-    // hash is resolved repeatedly. Volatile semantics keep the hash/ops pair
-    // consistent across concurrent readers and writers.
-    private static int _lastHash;
-    private static ActivationOps? _lastOps;
+    // Fast last-hit slot: skips the dictionary probe when the same mapping hash is
+    // resolved repeatedly. The slot is READ as a pair - "does the hash match? then take
+    // the ops" - so it must also be WRITTEN as a pair. Holding it as two fields cannot do
+    // that however they are marked: volatile orders each field on its own, it does not
+    // publish both at once, so two threads resolving different mappings can interleave
+    // into a stored hash from one and stored ops from the other. One immutable record
+    // behind one reference write makes the pair indivisible.
+    private sealed record LastHit(int Hash, ActivationOps Ops);
+    private static LastHit? _lastHit;
 
     // Type-indexed cache: keyed by the config runtime type so a repeated
     // Create(config) call with an equal SharpMindConfig (a sealed record, so
@@ -76,13 +80,12 @@ public static class ActivationFactory
     {
         int hash = MappingHash.Compute(mappings);
 
-        if (Volatile.Read(ref _lastHash) == hash && Volatile.Read(ref _lastOps) is { } hit)
-            return hit;
+        if (Volatile.Read(ref _lastHit) is { } hit && hit.Hash == hash)
+            return hit.Ops;
 
         var ops = _opsCache.GetOrAdd(hash, _ => Assembler.CreateInstance<ActivationOps>(mappings));
 
-        Volatile.Write(ref _lastHash, hash);
-        Volatile.Write(ref _lastOps, ops);
+        Volatile.Write(ref _lastHit, new LastHit(hash, ops));
         return ops;
     }
 }

--- a/SharpMind.Tests/Core/ActivationTests.cs
+++ b/SharpMind.Tests/Core/ActivationTests.cs
@@ -263,5 +263,33 @@ namespace SharpMind.Tests.Core
             var m2 = cfg.ToJigSawMapping();
             Assert.Same(ActivationFactory.Create(m1), ActivationFactory.Create(m2));
         }
+
+        [Fact]
+        public void Factory_ConcurrentAlternatingMappings_NeverServesAnotherMappingsOps()
+        {
+            // The last-hit slot is read as a pair (does the hash match? then take the ops),
+            // so it must be written as a pair. Two threads resolving different mappings can
+            // otherwise interleave into a state where the stored hash belongs to one mapping
+            // and the stored ops to the other, and the next caller is handed the wrong
+            // kernels - GELU where it asked for SwiGLU. That is silent: the ops are valid,
+            // just not the ones requested.
+            var mapA = (SharpMindConfig.Llama with { Hardware = HardwareTier.Scalar }).ToJigSawMapping();
+            var mapB = (SharpMindConfig.Gpt with { Hardware = HardwareTier.Scalar }).ToJigSawMapping();
+
+            var opsA = ActivationFactory.Create(mapA);
+            var opsB = ActivationFactory.Create(mapB);
+            Assert.NotSame(opsA, opsB);
+
+            int mismatches = 0;
+            Parallel.For(0, 400_000, i =>
+            {
+                bool wantA = (i & 1) == 0;
+                var got = ActivationFactory.Create(wantA ? mapA : mapB);
+                if (!ReferenceEquals(got, wantA ? opsA : opsB))
+                    Interlocked.Increment(ref mismatches);
+            });
+
+            Assert.Equal(0, mismatches);
+        }
     }
 }


### PR DESCRIPTION
`ActivationFactory` keeps a single-slot "last hit" cache in front of `_opsCache`, so that resolving the same mapping repeatedly skips the dictionary probe. The slot is **read as a pair** — if the stored hash matches, take the stored ops — but it was **written as two separate steps**:

```csharp
private static int _lastHash;
private static ActivationOps? _lastOps;
...
Volatile.Write(ref _lastHash, hash);
Volatile.Write(ref _lastOps, ops);
```

`volatile` orders each field individually. It does not publish both together, so two threads resolving *different* mappings can interleave into a state where the stored hash belongs to one mapping and the stored ops to the other:

```
A: _lastHash = Hx                      (preempted before its second write)
B: _lastHash = Hy;  _lastOps = OpsY
A: _lastOps = OpsX                     -> hash is Hy, ops are OpsX
```

The next caller asking for mapping **Y** now matches on the hash and is handed mapping **X**'s ops.

### Why this is worth fixing

It fails silently. The returned `ActivationOps` is perfectly valid and every call on it succeeds — it is simply not the one that was requested. In practice that means GELU where the caller asked for SwiGLU, or a scalar tier where it asked for AVX2.

`ModelFactory` (`ModelFactory.cs:201,278`) resolves through this factory on **every model construction**, so the visible effect is a model quietly built with another configuration's activation kernels. Nothing throws, and the output is plausible — just wrong, and only under concurrency.

### Fix

Hold the pair in one immutable record behind a single reference write, so publication is indivisible:

```csharp
private sealed record LastHit(int Hash, ActivationOps Ops);
private static LastHit? _lastHit;
```

The fast path is unchanged in cost — one volatile read, one integer compare. The only allocation is on a miss, i.e. when the resolved mapping actually changes.

### Proof

`Factory_ConcurrentAlternatingMappings_NeverServesAnotherMappingsOps` resolves two different mappings alternately across 400k concurrent calls and asserts each caller receives the ops it asked for.

Against the old code, on every run:

```
Assert.Equal() Failure: Values differ
Expected: 0
Actual:   281
```

Red 3 of 3 runs. After the fix, green 5 of 5. Full suite: `Passed! - Failed: 0, Passed: 954, Total: 954`.

I also checked the neighbours: `QuantizationFactory` and `GradientMappingFactory` hold only `ConcurrentDictionary` caches with no last-hit slot, and `ActivationFactory._typeCache` stores its `(Source, Ops)` as a single tuple value guarded by `hit.Source == config`, so neither can tear.
