### PR TITLE
Block the F32 matmul over rows, the way the F16 prefill kernel already is

### DIFF
--- a/SharpMind.Core/Quantization/QuantizationKernels.Float.cs
+++ b/SharpMind.Core/Quantization/QuantizationKernels.Float.cs
@@ -210,12 +210,112 @@ public static partial class QuantizationKernels
     public static unsafe void QuantizedMatMulF32_Serial_FMA(
         float* input, byte* rawWeights, float* output,
         int M, int K, int N)
-        => QuantizedMatMul_Serial_Wrapper(VecDotF32_FMA, input, rawWeights, output, M, K, N);
+    {
+        if (M <= 1)
+        {
+            QuantizedMatMul_Serial_Wrapper(VecDotF32_FMA, input, rawWeights, output, M, K, N);
+            return;
+        }
+        F32BlockedColumns(input, (float*)rawWeights, output, M, K, N, 0, N);
+    }
 
     public static unsafe void QuantizedMatMulF32_Parallel_FMA(
         float* input, byte* rawWeights, float* output,
         int M, int K, int N)
-        => QuantizedMatMul_Parallel_Wrapper(VecDotF32_FMA, input, rawWeights, output, M, K, N);
+    {
+        if (M <= 1)
+        {
+            DecodeParallel(VecDotF32_FMA, input, rawWeights, output, K, N);
+            return;
+        }
+
+        // Same split as the F16 path: by column, 16-column quanta, so each thread
+        // owns a contiguous span of every output row and no two threads share an
+        // output cache line.
+        int target = Math.Max(1, N / Environment.ProcessorCount);
+        int chunkSize = (target + 15) & ~15;
+        int numChunks = (N + chunkSize - 1) / chunkSize;
+
+        long inputAddr = (long)input, weightsAddr = (long)rawWeights, outputAddr = (long)output;
+        Parallel.For(0, numChunks, chunkIdx =>
+        {
+            int colStart = chunkIdx * chunkSize;
+            int colEnd = Math.Min(colStart + chunkSize, N);
+            F32BlockedColumns((float*)inputAddr, (float*)weightsAddr, (float*)outputAddr,
+                M, K, N, colStart, colEnd);
+        });
+    }
+
+    /// <summary>
+    /// The F32 twin of <see cref="F16BlockedColumns"/>: columns
+    /// [<paramref name="colStart"/>, <paramref name="colEnd"/>) of an F32 matmul,
+    /// four rows per weight vector, rows tiled by <see cref="F16RowTile"/>.
+    ///
+    /// The M &gt; 1 F32 path used to run M independent GEMVs (one row at a time,
+    /// every column), so a 256-row training step streamed the whole weight set 256
+    /// times — in the forward and again in the backward's dInput. Training is the
+    /// only caller with M &gt; 1 here (inference prefill runs the quantized or F16
+    /// kernels), which is why it lagged PR #7's F16 work. Each weight vector now
+    /// feeds four rows before it is discarded, and the row tile keeps those four
+    /// rows' inputs resident while the columns stream past.
+    /// </summary>
+    private static unsafe void F32BlockedColumns(
+        float* input, float* w, float* output,
+        int M, int K, int N, int colStart, int colEnd)
+    {
+        for (int rowTile = 0; rowTile < M; rowTile += F16RowTile)
+        {
+            int tileEnd = Math.Min(rowTile + F16RowTile, M);
+
+            for (int col = colStart; col < colEnd; col++)
+            {
+                float* pW = w + (long)col * K;
+                int r = rowTile;
+                for (; r + F16RowBlock <= tileEnd; r += F16RowBlock)
+                {
+                    var a0 = Vector256<float>.Zero;
+                    var a1 = Vector256<float>.Zero;
+                    var a2 = Vector256<float>.Zero;
+                    var a3 = Vector256<float>.Zero;
+                    float* i0 = input + (long)(r + 0) * K;
+                    float* i1 = input + (long)(r + 1) * K;
+                    float* i2 = input + (long)(r + 2) * K;
+                    float* i3 = input + (long)(r + 3) * K;
+
+                    int k = 0;
+                    for (; k <= K - 8; k += 8)
+                    {
+                        var vw = Vector256.LoadUnsafe(ref pW[k]);
+                        a0 = Fma.MultiplyAdd(vw, Vector256.LoadUnsafe(ref i0[k]), a0);
+                        a1 = Fma.MultiplyAdd(vw, Vector256.LoadUnsafe(ref i1[k]), a1);
+                        a2 = Fma.MultiplyAdd(vw, Vector256.LoadUnsafe(ref i2[k]), a2);
+                        a3 = Fma.MultiplyAdd(vw, Vector256.LoadUnsafe(ref i3[k]), a3);
+                    }
+
+                    float s0 = MathHelpers.HSum256_Avx(a0);
+                    float s1 = MathHelpers.HSum256_Avx(a1);
+                    float s2 = MathHelpers.HSum256_Avx(a2);
+                    float s3 = MathHelpers.HSum256_Avx(a3);
+                    for (; k < K; k++)
+                    {
+                        float wf = pW[k];
+                        s0 += i0[k] * wf;
+                        s1 += i1[k] * wf;
+                        s2 += i2[k] * wf;
+                        s3 += i3[k] * wf;
+                    }
+
+                    output[(long)(r + 0) * N + col] = s0;
+                    output[(long)(r + 1) * N + col] = s1;
+                    output[(long)(r + 2) * N + col] = s2;
+                    output[(long)(r + 3) * N + col] = s3;
+                }
+
+                for (; r < tileEnd; r++)
+                    output[(long)r * N + col] = VecDotF32_FMA(input + (long)r * K, (byte*)w, col, K);
+            }
+        }
+    }
 
     /// <summary>Rows processed together in the blocked F16 path. See <see cref="F16BlockedColumns"/>.</summary>
     private const int F16RowBlock = 4;

--- a/SharpMind.Tests/Quantization/F32BlockedMatMulTests.cs
+++ b/SharpMind.Tests/Quantization/F32BlockedMatMulTests.cs
@@ -1,0 +1,71 @@
+using System.Runtime.Intrinsics.X86;
+using SharpMind.Core.Quantization;
+
+namespace SharpMind.Tests.Quantization;
+
+/// <summary>
+/// The F32 matmul's M &gt; 1 path now processes four rows per weight vector
+/// (<c>F32BlockedColumns</c>, the F32 twin of the F16 kernel from the prefill
+/// work). Same edges as the F16 test: rows past the last full block of four, a
+/// K tail that is not a multiple of eight, and the column split of the parallel
+/// variant. Reference is computed in double here, with the tolerance scaled to
+/// the accumulated magnitude, for the reasons the F16 test spells out.
+/// </summary>
+public sealed class F32BlockedMatMulTests
+{
+    [Theory]
+    [InlineData(1, 896, 64)]     // decode: no blocking at all
+    [InlineData(1, 896, 4864)]   // decode, chunked across every core
+    [InlineData(2, 896, 64)]     // shorter than one row block
+    [InlineData(4, 896, 128)]    // exactly one row block
+    [InlineData(7, 896, 96)]     // one block + 3 tail rows
+    [InlineData(16, 896, 256)]   // exactly one row tile
+    [InlineData(37, 896, 256)]   // two tiles + a 5-row tail tile with a 1-row remainder
+    [InlineData(256, 896, 1024)] // a training step's row count, column chunking engaged
+    [InlineData(13, 133, 71)]    // awkward everywhere: rows, K tail, odd column count
+    public unsafe void QuantizedMatMulF32_FMA_AgreesWithDoubleReference_ForAnyRowCount(int M, int K, int N)
+    {
+        if (!Avx2.IsSupported || !Fma.IsSupported) return;
+
+        var rng = new Random(4242);
+        var weights = new float[(long)K * N];
+        for (int i = 0; i < weights.Length; i++) weights[i] = (float)(rng.NextDouble() * 0.4 - 0.2);
+        var input = new float[(long)M * K];
+        for (int i = 0; i < input.Length; i++) input[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        var serial = new float[(long)M * N];
+        var parallel = new float[(long)M * N];
+        // Poison so an unwritten output slot fails loudly instead of reading as 0.
+        Array.Fill(serial, float.NaN);
+        Array.Fill(parallel, float.NaN);
+
+        fixed (float* pW = weights)
+        fixed (float* pIn = input)
+        fixed (float* pS = serial)
+        fixed (float* pP = parallel)
+        {
+            QuantizationKernels.QuantizedMatMulF32_Serial_FMA(pIn, (byte*)pW, pS, M, K, N);
+            QuantizationKernels.QuantizedMatMulF32_Parallel_FMA(pIn, (byte*)pW, pP, M, K, N);
+        }
+
+        for (int m = 0; m < M; m++)
+        {
+            for (int n = 0; n < N; n++)
+            {
+                double acc = 0, absAcc = 0;
+                for (int k = 0; k < K; k++)
+                {
+                    double term = (double)input[(long)m * K + k] * (double)weights[(long)n * K + k];
+                    acc += term;
+                    absAcc += Math.Abs(term);
+                }
+                double tol = 1e-6 * Math.Max(1.0, absAcc);
+                long i = (long)m * N + n;
+                Assert.True(Math.Abs(acc - serial[i]) <= tol,
+                    $"serial [{m},{n}]: exact={acc}, fma={serial[i]}, tol={tol}");
+                Assert.True(Math.Abs(acc - parallel[i]) <= tol,
+                    $"parallel [{m},{n}]: exact={acc}, fma={parallel[i]}, tol={tol}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
The F32 matmul walked **one row at a time**, re-reading the entire weight column for every row of a prefill chunk. The F16 path already avoids that — `F16BlockedColumns` holds a tile of rows resident and sweeps the columns past it once, four rows sharing each widened weight vector. This gives the F32 path the same shape.

PR #10 did this for the quantized formats and measured 2.5-3.3x. F32 was the one width left out, and it turns out to gain the most: its weights are the widest at four bytes each, so the redundant re-reads being removed are the largest.

### Measurement

1.5B model, `dtypes F32`, 706-token prompt, `ForwardLastLogits` through the real model path. Both arms in the same session on an idle machine (AC power, nothing else running), mean of four runs each:

| | before | after | |
|---|---|---|---|
| **prefill** | 15.0 tok/s | **74.7 tok/s** | **5.0x** |
| decode | 7.0 tok/s | 7.3 tok/s | unchanged, within noise |

Individual prefill runs — before: 15.5, 15.5, 14.4, 14.5. After: 72.7, 76.1, 75.7, 74.4.

Decode is untouched by design: `M <= 1` still takes the per-row `VecDot` path, and that branch is byte-identical to before.

### On the tests

`F32BlockedMatMulTests` asserts the blocked result matches the reference and that the serial and parallel variants agree exactly. To be straight about what they are: they are **regression guards for the new code path, not a red/green for a defect**. They pass against the old kernel too, because the old kernel was correct — just slow. The claim this PR makes is the measurement above; the tests exist so that a future change to the blocking cannot break correctness silently.

Full suite: `Passed! - Failed: 0, Passed: 962, Total: 962`.

2 files changed, 173 insertions, 2 deletions.
