### PR TITLE
Unpack Q4_K, Q6_K and Q5_0 weights with vector ops, not through a stack buffer

### DIFF
--- a/SharpMind.Core/Quantization/QuantizationKernels.Q4.cs
+++ b/SharpMind.Core/Quantization/QuantizationKernels.Q4.cs
@@ -622,6 +622,16 @@ public static partial class QuantizationKernels
         return (float)sum;
     }
 
+    /// <summary>
+    /// Eight consecutive Q4_K nibbles as floats. A 32-value sub-block that starts
+    /// on a 32 boundary lives in one contiguous run of 32 bytes: chunk
+    /// <c>basePos/64</c> of <paramref name="qs"/>, low nibbles for the first 32
+    /// values of the chunk and high nibbles for the next 32. So group
+    /// <paramref name="g"/> of the sub-block is bytes <c>[8g, 8g+8)</c> of that
+    /// run, widened straight from memory (vpmovzxbd) and masked or shifted —
+    /// never decoded one weight at a time into a stack buffer, which cannot
+    /// store-forward into the vector load that follows it.
+    /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe float VecDotQ4K_AVX2(float* input, byte* rawWeights, int col, int inFeatures)
     {
@@ -630,7 +640,8 @@ public static partial class QuantizationKernels
         int colBlockStart = col * inFeatures % QK_K;
         int nBlocks = (inFeatures + QK_K - 1) / QK_K;
         double sum = 0;
-        float* vvBuf = stackalloc float[8];
+        var vacc0 = Vector256<float>.Zero;
+        var vacc1 = Vector256<float>.Zero;
         for (int b = 0; b < nBlocks; b++)
         {
             byte* block = rawWeights + (long)(startBlock + b) * BLOCK_BYTES;
@@ -655,19 +666,20 @@ public static partial class QuantizationKernels
 
                     int subRem = Math.Min(32, blockEnd - basePos);
                     int l = 0;
-                    for (; l <= subRem - 8; l += 8)
+                    if ((basePos & 31) == 0)
                     {
-                        for (int sub = 0; sub < 8; sub++)
+                        for (; l <= subRem - 16; l += 16)
                         {
-                            int idx = basePos + l + sub;
-                            int qsByte = (idx / 64) * 32 + (idx % 32);
-                            int qsShift = ((idx % 64) / 32) * 4;
-                            vvBuf[sub] = (qs[qsByte] >> qsShift) & 0x0F;
+                            var vw0 = Avx.Subtract(Avx.Multiply(Q4KNibbles8(qs, basePos, l >> 3), vs), vm);
+                            var vw1 = Avx.Subtract(Avx.Multiply(Q4KNibbles8(qs, basePos, (l >> 3) + 1), vs), vm);
+                            vacc0 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[basePos + l]), vw0), vacc0);
+                            vacc1 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[basePos + l + 8]), vw1), vacc1);
                         }
-                        var vv = Vector256.LoadUnsafe(ref vvBuf[0]);
-                        var vi = Vector256.LoadUnsafe(ref pIn[basePos + l]);
-                        var res = Avx.Multiply(vi, Avx.Subtract(Avx.Multiply(vv, vs), vm));
-                        sum += MathHelpers.HSum256_Avx(res);
+                        for (; l <= subRem - 8; l += 8)
+                        {
+                            var vw = Avx.Subtract(Avx.Multiply(Q4KNibbles8(qs, basePos, l >> 3), vs), vm);
+                            vacc0 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[basePos + l]), vw), vacc0);
+                        }
                     }
                     for (; l < subRem; l++)
                     {
@@ -680,6 +692,7 @@ public static partial class QuantizationKernels
                 }
             }
         }
+        sum += MathHelpers.HSum256_Avx(Avx.Add(vacc0, vacc1));
         return (float)sum;
     }
 
@@ -691,8 +704,8 @@ public static partial class QuantizationKernels
         int colBlockStart = col * inFeatures % QK_K;
         int nBlocks = (inFeatures + QK_K - 1) / QK_K;
         double sum = 0;
-        float* vvBuf = stackalloc float[8];
-        var vacc = Vector256<float>.Zero;
+        var vacc0 = Vector256<float>.Zero;
+        var vacc1 = Vector256<float>.Zero;
         for (int b = 0; b < nBlocks; b++)
         {
             byte* block = rawWeights + (long)(startBlock + b) * BLOCK_BYTES;
@@ -717,19 +730,20 @@ public static partial class QuantizationKernels
 
                     int subRem = Math.Min(32, blockEnd - basePos);
                     int l = 0;
-                    for (; l <= subRem - 8; l += 8)
+                    if ((basePos & 31) == 0)
                     {
-                        for (int sub = 0; sub < 8; sub++)
+                        for (; l <= subRem - 16; l += 16)
                         {
-                            int idx = basePos + l + sub;
-                            int qsByte = (idx / 64) * 32 + (idx % 32);
-                            int qsShift = ((idx % 64) / 32) * 4;
-                            vvBuf[sub] = (qs[qsByte] >> qsShift) & 0x0F;
+                            var vw0 = Fma.MultiplySubtract(Q4KNibbles8(qs, basePos, l >> 3), vs, vm);
+                            var vw1 = Fma.MultiplySubtract(Q4KNibbles8(qs, basePos, (l >> 3) + 1), vs, vm);
+                            vacc0 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[basePos + l]), vw0, vacc0);
+                            vacc1 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[basePos + l + 8]), vw1, vacc1);
                         }
-                        var vv = Vector256.LoadUnsafe(ref vvBuf[0]);
-                        var vi = Vector256.LoadUnsafe(ref pIn[basePos + l]);
-                        var vw = Avx.Subtract(Avx.Multiply(vv, vs), vm);
-                        vacc = Fma.MultiplyAdd(vi, vw, vacc);
+                        for (; l <= subRem - 8; l += 8)
+                        {
+                            var vw = Fma.MultiplySubtract(Q4KNibbles8(qs, basePos, l >> 3), vs, vm);
+                            vacc0 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[basePos + l]), vw, vacc0);
+                        }
                     }
                     for (; l < subRem; l++)
                     {
@@ -742,7 +756,7 @@ public static partial class QuantizationKernels
                 }
             }
         }
-        sum += MathHelpers.HSum256_Avx(vacc);
+        sum += MathHelpers.HSum256_Avx(Avx.Add(vacc0, vacc1));
         return (float)sum;
     }
 

--- a/SharpMind.Core/Quantization/QuantizationKernels.Q5.cs
+++ b/SharpMind.Core/Quantization/QuantizationKernels.Q5.cs
@@ -44,78 +44,6 @@ public static partial class QuantizationKernels
         const int QK = 32;
         int nBlocks = (inFeatures + QK - 1) / QK;
         double sum = 0;
-        float* vvBuf = stackalloc float[8];
-        for (int b = 0; b < nBlocks; b++)
-        {
-            byte* block = rawWeights + (long)col * nBlocks * BLOCK_BYTES + b * BLOCK_BYTES;
-            float d = HalfToFloat_F16C(*(ushort*)block);
-            uint qh = *(uint*)(block + 2);
-            byte* qs = block + 6;
-            int blockEnd = Math.Min(QK, inFeatures - b * QK);
-            float* pIn = input + b * QK;
-            var vd = Vector256.Create(d);
-            int half = QK / 2;
-
-            var vacc0 = Vector256<float>.Zero;
-            var vacc1 = Vector256<float>.Zero;
-            int i = 0;
-            for (; i <= blockEnd - 16; i += 16)
-            {
-                for (int sub = 0; sub < 8; sub++)
-                {
-                    int idx = i + sub;
-                    int h4 = ((int)(qh >> idx) & 1) << 4;
-                    int nib = (idx < half) ? (qs[idx] & 0x0F) : (qs[idx - half] >> 4);
-                    vvBuf[sub] = ((nib | h4) - 16) * d;
-                }
-                var vw0 = Vector256.LoadUnsafe(ref vvBuf[0]);
-                var vi0 = Vector256.LoadUnsafe(ref pIn[i]);
-                vacc0 = Avx.Add(vacc0, Avx.Multiply(vi0, vw0));
-
-                for (int sub = 0; sub < 8; sub++)
-                {
-                    int idx = i + 8 + sub;
-                    int h4 = ((int)(qh >> idx) & 1) << 4;
-                    int nib = (idx < half) ? (qs[idx] & 0x0F) : (qs[idx - half] >> 4);
-                    vvBuf[sub] = ((nib | h4) - 16) * d;
-                }
-                var vw1 = Vector256.LoadUnsafe(ref vvBuf[0]);
-                var vi1 = Vector256.LoadUnsafe(ref pIn[i + 8]);
-                vacc1 = Avx.Add(vacc1, Avx.Multiply(vi1, vw1));
-            }
-            for (; i <= blockEnd - 8; i += 8)
-            {
-                for (int sub = 0; sub < 8; sub++)
-                {
-                    int idx = i + sub;
-                    int h4 = ((int)(qh >> idx) & 1) << 4;
-                    int nib = (idx < half) ? (qs[idx] & 0x0F) : (qs[idx - half] >> 4);
-                    vvBuf[sub] = ((nib | h4) - 16) * d;
-                }
-                var vw = Vector256.LoadUnsafe(ref vvBuf[0]);
-                var vi = Vector256.LoadUnsafe(ref pIn[i]);
-                vacc0 = Avx.Add(vacc0, Avx.Multiply(vi, vw));
-            }
-            sum += MathHelpers.HSum256_Avx(Avx.Add(vacc0, vacc1));
-            for (; i < blockEnd; i++)
-            {
-                int h4 = ((int)(qh >> i) & 1) << 4;
-                int nib = (i < half) ? (qs[i] & 0x0F) : (qs[i - half] >> 4);
-                int q = nib | h4;
-                sum += pIn[i] * ((q - 16) * d);
-            }
-        }
-        return (float)sum;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe float VecDotQ5_0_FMA(float* input, byte* rawWeights, int col, int inFeatures)
-    {
-        const int BLOCK_BYTES = 22;
-        const int QK = 32;
-        int nBlocks = (inFeatures + QK - 1) / QK;
-        double sum = 0;
-        float* vvBuf = stackalloc float[8];
         var vacc0 = Vector256<float>.Zero;
         var vacc1 = Vector256<float>.Zero;
         for (int b = 0; b < nBlocks; b++)
@@ -129,42 +57,67 @@ public static partial class QuantizationKernels
             int half = QK / 2;
 
             int i = 0;
-            for (; i <= blockEnd - 16; i += 16)
+            if (blockEnd == QK)
             {
-                for (int sub = 0; sub < 8; sub++)
-                {
-                    int idx = i + sub;
-                    int h4 = ((int)(qh >> idx) & 1) << 4;
-                    int nib = (idx < half) ? (qs[idx] & 0x0F) : (qs[idx - half] >> 4);
-                    vvBuf[sub] = ((nib | h4) - 16) * d;
-                }
-                var vw0 = Vector256.LoadUnsafe(ref vvBuf[0]);
-                var vi0 = Vector256.LoadUnsafe(ref pIn[i]);
-                vacc0 = Fma.MultiplyAdd(vi0, vw0, vacc0);
-
-                for (int sub = 0; sub < 8; sub++)
-                {
-                    int idx = i + 8 + sub;
-                    int h4 = ((int)(qh >> idx) & 1) << 4;
-                    int nib = (idx < half) ? (qs[idx] & 0x0F) : (qs[idx - half] >> 4);
-                    vvBuf[sub] = ((nib | h4) - 16) * d;
-                }
-                var vw1 = Vector256.LoadUnsafe(ref vvBuf[0]);
-                var vi1 = Vector256.LoadUnsafe(ref pIn[i + 8]);
-                vacc1 = Fma.MultiplyAdd(vi1, vw1, vacc1);
+                var vd = Vector256.Create(d);
+                var v16d = Vector256.Create(16 * d);
+                var qhv = Vector256.Create(qh);
+                var w0 = Avx.Subtract(Avx.Multiply(Q5_0Codes8(qs, 0, qhv, Q5Bits0), vd), v16d);
+                var w1 = Avx.Subtract(Avx.Multiply(Q5_0Codes8(qs, 1, qhv, Q5Bits1), vd), v16d);
+                var w2 = Avx.Subtract(Avx.Multiply(Q5_0Codes8(qs, 2, qhv, Q5Bits2), vd), v16d);
+                var w3 = Avx.Subtract(Avx.Multiply(Q5_0Codes8(qs, 3, qhv, Q5Bits3), vd), v16d);
+                vacc0 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[0]), w0), vacc0);
+                vacc1 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[8]), w1), vacc1);
+                vacc0 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[16]), w2), vacc0);
+                vacc1 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[24]), w3), vacc1);
+                i = QK;
             }
-            for (; i <= blockEnd - 8; i += 8)
+            for (; i < blockEnd; i++)
             {
-                for (int sub = 0; sub < 8; sub++)
-                {
-                    int idx = i + sub;
-                    int h4 = ((int)(qh >> idx) & 1) << 4;
-                    int nib = (idx < half) ? (qs[idx] & 0x0F) : (qs[idx - half] >> 4);
-                    vvBuf[sub] = ((nib | h4) - 16) * d;
-                }
-                var vw = Vector256.LoadUnsafe(ref vvBuf[0]);
-                var vi = Vector256.LoadUnsafe(ref pIn[i]);
-                vacc0 = Fma.MultiplyAdd(vi, vw, vacc0);
+                int h4 = ((int)(qh >> i) & 1) << 4;
+                int nib = (i < half) ? (qs[i] & 0x0F) : (qs[i - half] >> 4);
+                int q = nib | h4;
+                sum += pIn[i] * ((q - 16) * d);
+            }
+        }
+        sum += MathHelpers.HSum256_Avx(Avx.Add(vacc0, vacc1));
+        return (float)sum;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe float VecDotQ5_0_FMA(float* input, byte* rawWeights, int col, int inFeatures)
+    {
+        const int BLOCK_BYTES = 22;
+        const int QK = 32;
+        int nBlocks = (inFeatures + QK - 1) / QK;
+        double sum = 0;
+        var vacc0 = Vector256<float>.Zero;
+        var vacc1 = Vector256<float>.Zero;
+        for (int b = 0; b < nBlocks; b++)
+        {
+            byte* block = rawWeights + (long)col * nBlocks * BLOCK_BYTES + b * BLOCK_BYTES;
+            float d = HalfToFloat_F16C(*(ushort*)block);
+            uint qh = *(uint*)(block + 2);
+            byte* qs = block + 6;
+            int blockEnd = Math.Min(QK, inFeatures - b * QK);
+            float* pIn = input + b * QK;
+            int half = QK / 2;
+
+            int i = 0;
+            if (blockEnd == QK)
+            {
+                var vd = Vector256.Create(d);
+                var v16d = Vector256.Create(16 * d);
+                var qhv = Vector256.Create(qh);
+                var w0 = Fma.MultiplySubtract(Q5_0Codes8(qs, 0, qhv, Q5Bits0), vd, v16d);
+                var w1 = Fma.MultiplySubtract(Q5_0Codes8(qs, 1, qhv, Q5Bits1), vd, v16d);
+                var w2 = Fma.MultiplySubtract(Q5_0Codes8(qs, 2, qhv, Q5Bits2), vd, v16d);
+                var w3 = Fma.MultiplySubtract(Q5_0Codes8(qs, 3, qhv, Q5Bits3), vd, v16d);
+                vacc0 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[0]), w0, vacc0);
+                vacc1 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[8]), w1, vacc1);
+                vacc0 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[16]), w2, vacc0);
+                vacc1 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[24]), w3, vacc1);
+                i = QK;
             }
             for (; i < blockEnd; i++)
             {

--- a/SharpMind.Core/Quantization/QuantizationKernels.Q6.cs
+++ b/SharpMind.Core/Quantization/QuantizationKernels.Q6.cs
@@ -72,6 +72,10 @@ public static partial class QuantizationKernels
         int colBlockStart = col * inFeatures % QK_K;
         int nBlocks = (inFeatures + QK_K - 1) / QK_K;
         double sum = 0;
+        var vacc0 = Vector256<float>.Zero;
+        var vacc1 = Vector256<float>.Zero;
+        var vacc2 = Vector256<float>.Zero;
+        var vacc3 = Vector256<float>.Zero;
         for (int b = 0; b < nBlocks; b++)
         {
             byte* block = rawWeights + (long)(startBlock + b) * BLOCK_BYTES;
@@ -90,7 +94,24 @@ public static partial class QuantizationKernels
                 sbyte* psc = scales + (nOff == 0 ? 0 : 8);
 
                 int halfRem = Math.Min(128, blockEnd - nOff);
-                for (int l = 0; l < 32 && l < halfRem; l++)
+
+                int l = 0;
+                for (; l + 103 < halfRem && l < 32; l += 8)
+                {
+                    int is_ = l / 16;
+                    Q6KCodes8(pql, pqh, l, out var q1, out var q2, out var q3, out var q4);
+                    float s1 = d * psc[is_ + 0], s2 = d * psc[is_ + 2], s3 = d * psc[is_ + 4], s4 = d * psc[is_ + 6];
+                    var vw1 = Avx.Subtract(Avx.Multiply(q1, Vector256.Create(s1)), Vector256.Create(32 * s1));
+                    var vw2 = Avx.Subtract(Avx.Multiply(q2, Vector256.Create(s2)), Vector256.Create(32 * s2));
+                    var vw3 = Avx.Subtract(Avx.Multiply(q3, Vector256.Create(s3)), Vector256.Create(32 * s3));
+                    var vw4 = Avx.Subtract(Avx.Multiply(q4, Vector256.Create(s4)), Vector256.Create(32 * s4));
+                    vacc0 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[nOff + l]), vw1), vacc0);
+                    vacc1 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[nOff + l + 32]), vw2), vacc1);
+                    vacc2 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[nOff + l + 64]), vw3), vacc2);
+                    vacc3 = Avx.Add(Avx.Multiply(Vector256.LoadUnsafe(ref pIn[nOff + l + 96]), vw4), vacc3);
+                }
+
+                for (; l < halfRem && l < 32; l++)
                 {
                     int is_ = l / 16;
                     int q1v = (pql[l] & 0x0F) | ((pqh[l] & 0x03) << 4);
@@ -123,6 +144,7 @@ public static partial class QuantizationKernels
                 }
             }
         }
+        sum += MathHelpers.HSum256_Avx(Avx.Add(Avx.Add(vacc0, vacc1), Avx.Add(vacc2, vacc3)));
         return (float)sum;
     }
 
@@ -134,7 +156,6 @@ public static partial class QuantizationKernels
         int colBlockStart = col * inFeatures % QK_K;
         int nBlocks = (inFeatures + QK_K - 1) / QK_K;
         double sum = 0;
-        float* vvBuf = stackalloc float[8];
         var vacc0 = Vector256<float>.Zero;
         var vacc1 = Vector256<float>.Zero;
         var vacc2 = Vector256<float>.Zero;
@@ -162,39 +183,16 @@ public static partial class QuantizationKernels
                 for (; l + 103 < halfRem && l < 32; l += 8)
                 {
                     int is_ = l / 16;
-                    int sOff = is_ == 0 ? 0 : 1;
-
-                    for (int sub = 0; sub < 8; sub++)
-                    {
-                        int idx = l + sub;
-                        int q1v = (pql[idx] & 0x0F) | ((pqh[idx] & 0x03) << 4);
-                        vvBuf[sub] = d * psc[sOff + 0] * (q1v - 32);
-                    }
-                    vacc0 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[nOff + l]), Vector256.LoadUnsafe(ref vvBuf[0]), vacc0);
-
-                    for (int sub = 0; sub < 8; sub++)
-                    {
-                        int idx = l + sub;
-                        int q2v = (pql[idx + 32] & 0x0F) | (((pqh[idx] >> 2) & 0x03) << 4);
-                        vvBuf[sub] = d * psc[sOff + 2] * (q2v - 32);
-                    }
-                    vacc1 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[nOff + l + 32]), Vector256.LoadUnsafe(ref vvBuf[0]), vacc1);
-
-                    for (int sub = 0; sub < 8; sub++)
-                    {
-                        int idx = l + sub;
-                        int q3v = ((pql[idx] >> 4) & 0x0F) | (((pqh[idx] >> 4) & 0x03) << 4);
-                        vvBuf[sub] = d * psc[sOff + 4] * (q3v - 32);
-                    }
-                    vacc2 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[nOff + l + 64]), Vector256.LoadUnsafe(ref vvBuf[0]), vacc2);
-
-                    for (int sub = 0; sub < 8; sub++)
-                    {
-                        int idx = l + sub;
-                        int q4v = ((pql[idx + 32] >> 4) & 0x0F) | (((pqh[idx] >> 6) & 0x03) << 4);
-                        vvBuf[sub] = d * psc[sOff + 6] * (q4v - 32);
-                    }
-                    vacc3 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[nOff + l + 96]), Vector256.LoadUnsafe(ref vvBuf[0]), vacc3);
+                    Q6KCodes8(pql, pqh, l, out var q1, out var q2, out var q3, out var q4);
+                    float s1 = d * psc[is_ + 0], s2 = d * psc[is_ + 2], s3 = d * psc[is_ + 4], s4 = d * psc[is_ + 6];
+                    var vw1 = Fma.MultiplySubtract(q1, Vector256.Create(s1), Vector256.Create(32 * s1));
+                    var vw2 = Fma.MultiplySubtract(q2, Vector256.Create(s2), Vector256.Create(32 * s2));
+                    var vw3 = Fma.MultiplySubtract(q3, Vector256.Create(s3), Vector256.Create(32 * s3));
+                    var vw4 = Fma.MultiplySubtract(q4, Vector256.Create(s4), Vector256.Create(32 * s4));
+                    vacc0 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[nOff + l]), vw1, vacc0);
+                    vacc1 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[nOff + l + 32]), vw2, vacc1);
+                    vacc2 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[nOff + l + 64]), vw3, vacc2);
+                    vacc3 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref pIn[nOff + l + 96]), vw4, vacc3);
                 }
 
                 for (; l < halfRem && l < 32; l++)

--- a/SharpMind.Tests/Quantization/KQuantUnpackTests.cs
+++ b/SharpMind.Tests/Quantization/KQuantUnpackTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Intrinsics.X86;
+using SharpMind.Core;
+using SharpMind.Core.Quantization;
+using Xunit;
+
+namespace SharpMind.Tests.Quantization;
+
+/// <summary>
+/// The Q4_K, Q6_K and Q5_0 vector kernels unpack packed weights straight from
+/// memory with vector shifts and masks. Q4_K reads a 32-value sub-block as one
+/// contiguous nibble run, Q6_K reassembles four interleaved groups from two
+/// nibble bytes and one high-bit byte, and Q5_0 pulls each weight's fifth bit
+/// out of a 32-bit mask with a per-lane shift. Each is easy to get subtly wrong
+/// — the wrong nibble half, the wrong bit pair, a mask applied before a shift —
+/// and the results would still look like plausible weights.
+///
+/// The existing agreement test only uses K as a multiple of the super-block, so
+/// it never sees a column that starts mid-block (K=896 puts every odd column at
+/// offset 128, which is exactly what qwen2-0.5b's ffn_down does), a column that
+/// starts off a 32 boundary (falls back to the per-weight path, which must agree
+/// too), or a partial final block. These do.
+/// </summary>
+public class KQuantUnpackTests
+{
+    public static IEnumerable<object[]> Cases()
+    {
+        foreach (var dtype in new[] { QuantDType.Q4_K, QuantDType.Q6_K, QuantDType.Q5_0 })
+            // 256/512: whole super-blocks. 896, 4864: qwen2 shapes, odd columns
+            // start at offset 128. 288/320/384: offsets 32/64/128. 8/20/137:
+            // partial blocks and columns off any alignment.
+            foreach (int k in new[] { 8, 20, 137, 256, 288, 320, 384, 512, 896, 4864 })
+                yield return new object[] { dtype, k };
+    }
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public unsafe void VectorisedTiersAgreeWithScalar(QuantDType dtype, int inFeatures)
+    {
+        if (!Avx2.IsSupported || !Fma.IsSupported) return;
+
+        const int nCols = 3;
+        const int Poison = 64;
+
+        int totalBytes = (int)QuantizationOps.GetRawTensorByteCount([inFeatures, nCols], dtype);
+        var raw = new byte[totalBytes];
+        var rng = new Random(4321 + inFeatures);
+        rng.NextBytes(raw);
+
+        // Pin every fp16 super-scale so random bytes cannot make it NaN/Inf.
+        // Q4_K: d at 0, dmin at 2 of 144. Q6_K: d at 208 of 210. Q5_0: d at 0 of 22.
+        (int blockBytes, int dOff, int minOff) = dtype switch
+        {
+            QuantDType.Q4_K => (144, 0, 2),
+            QuantDType.Q6_K => (210, 208, -1),
+            _ => (22, 0, -1),
+        };
+        for (int off = 0; off + blockBytes <= raw.Length; off += blockBytes)
+        {
+            raw[off + dOff] = 0x00; raw[off + dOff + 1] = 0x38;                       // 0.5
+            if (minOff >= 0) { raw[off + minOff] = 0x00; raw[off + minOff + 1] = 0x34; } // 0.25
+        }
+
+        // Loud padding past K: an unpack that reaches into the next block's
+        // input picks up 1e6 and blows the tolerance rather than reading zeros.
+        var input = new float[inFeatures + Poison];
+        for (int i = 0; i < inFeatures; i++) input[i] = (float)(rng.NextDouble() * 2 - 1);
+        for (int i = inFeatures; i < input.Length; i++) input[i] = 1e6f;
+
+        var scalar = QuantizationFactory.Create(HardwareTier.Scalar);
+        var avx2 = QuantizationFactory.Create(HardwareTier.AVX2);
+        var fma = QuantizationFactory.Create(HardwareTier.FMA);
+
+        fixed (float* pIn = input)
+        fixed (byte* pW = raw)
+        {
+            for (int c = 0; c < nCols; c++)
+            {
+                float expected = Dot(scalar, dtype, pIn, pW, c, inFeatures);
+                float gotAvx2 = Dot(avx2, dtype, pIn, pW, c, inFeatures);
+                float gotFma = Dot(fma, dtype, pIn, pW, c, inFeatures);
+
+                // Scalar accumulates in double; the vector kernels in float
+                // across up to 4864 terms, so the bound scales with magnitude.
+                float tol = 2e-4f * Math.Max(1f, Math.Abs(expected));
+                Assert.True(Math.Abs(expected - gotAvx2) <= tol,
+                    $"{dtype} K={inFeatures} col={c}: scalar={expected}, avx2={gotAvx2}");
+                Assert.True(Math.Abs(expected - gotFma) <= tol,
+                    $"{dtype} K={inFeatures} col={c}: scalar={expected}, fma={gotFma}");
+            }
+        }
+    }
+
+    private static unsafe float Dot(QuantizationOps ops, QuantDType dtype, float* pIn, byte* pW, int col, int k) => dtype switch
+    {
+        QuantDType.Q4_K => ops.VecDotQ4K(pIn, pW, col, k),
+        QuantDType.Q6_K => ops.VecDotQ6K(pIn, pW, col, k),
+        _ => ops.VecDotQ5_0(pIn, pW, col, k),
+    };
+}


### PR DESCRIPTION
The vectorised vecdots for Q4_K, Q6_K and Q5_0 decode weights **one at a time** into a `stackalloc float[8]`, then vector-load that same buffer:

```csharp
float* vvBuf = stackalloc float[8];
...
for (int sub = 0; sub < 8; sub++)
    vvBuf[sub] = <decode one weight>;
var vv = Vector256.LoadUnsafe(ref vvBuf[0]);
```

Eight 4-byte stores followed by a 32-byte load off the same address cannot store-forward. That is a guaranteed stall, once per 8 weights, sitting inside the kernels named `_AVX2` and `_FMA` — on top of the scalar decode itself. It is the same shape that made the F16 kernel slower than its own scalar fallback before `8906f42` removed it there.

### Fix

Packed bytes are widened straight from memory (`vpmovzxbd`), fields separated with vector shifts and masks, converted once, and the block scale applied as a single FMA. Q5_0's fifth bits are broadcast once per block, with each lane shifting its own bit down. `VecDotQ4K_AVX2` additionally ran a full `HSum256_Avx` **inside** its inner loop, every 8 elements; it now accumulates into a vector and reduces once at the end. Misaligned sub-blocks and partial blocks keep the per-weight path, so any K still agrees with the scalar kernel.

The helpers this needs — `Q4KNibbles8`, `Q5_0Codes8`, `Q6KCodes8`, `Q5Bits0..3` — already exist for the blocked prefill driver, so they are reused rather than duplicated.

### Measurement

`qwen2-0_5b-instruct-q4_k_m`, 706-token prompt, both arms in the same session on an idle machine, mean of three runs:

| | before | after | |
|---|---|---|---|
| **decode** | 10.3 tok/s | **55.9 tok/s** | **5.4x** |
| prefill | 222 tok/s | 227 tok/s | unchanged |

**Prefill is unchanged by design, not by accident.** The blocked driver already dequantises each column once per chunk and never reaches these vecdots. This is the `M <= 1` path — decode — where a K-quantised model was paying the stall on every single token.

The effect is that q4_k_m decode now lands alongside q8_0 (~56 vs ~60 tok/s on this machine) instead of roughly 5x behind it, while reading 25% fewer bytes. Top-5 logits are identical before and after.

### Not covered

`Q2_K`, `Q3_K`, `Q5_1` and `Q5_K` carry the same pattern and are deliberately untouched — no model I have reaches them, so I have no way to measure a change there. The sites are `Q2.cs:68,160`, `Q3.cs:70,138`, `Q5.cs:218,290,400,500` if you want them done too.

### Tests

`KQuantUnpackTests` checks AVX2 and FMA against the scalar kernel for all three formats at K in `{8, 20, 137, 256, 288, 320, 384, 512, 896, 4864}` — values that hit the wide body, the narrow body, a partial block and a mid-super-block column start — with the input padded past K so an over-read is loud. Each unpack was verified red by flipping one detail (nibble half, bit pair, mask shift) and green as committed.

Full suite: `Passed! - Failed: 0, Passed: 983, Total: 983`.
