### PR TITLE
Default ToolsFolder instead of resolving PluginsFolder twice

### DIFF
--- a/SharpMind.CUI/App/AppSettings.cs
+++ b/SharpMind.CUI/App/AppSettings.cs
@@ -92,15 +92,27 @@ public sealed class AppSettings
             }
         }
         var settings = UnResolvedLoad();
-        if(string.IsNullOrWhiteSpace(settings.PluginsFolder) || !Directory.Exists(settings.PluginsFolder))
-        {
-            settings.PluginsFolder = GetDefaultPluginPath(settings.PluginsFolder);
-        }
-        if (string.IsNullOrWhiteSpace(settings.ToolsFolder) || !Directory.Exists(settings.PluginsFolder))
-        {
-            settings.PluginsFolder = GetDefaultPluginPath(settings.PluginsFolder);
-        }
+        ApplyFolderDefaults(settings, GetDefaultPluginPath);
         return settings;
+    }
+
+    /// <summary>
+    /// Points <see cref="PluginsFolder"/> and <see cref="ToolsFolder"/> at
+    /// <paramref name="resolveDefault"/> when they are unset or name a directory that is
+    /// no longer there. Separated from <see cref="Load"/>, with the resolver injected, so
+    /// the decision can be tested without touching the real settings file or creating
+    /// directories.
+    /// </summary>
+    internal static void ApplyFolderDefaults(AppSettings settings, Func<string?, string> resolveDefault)
+    {
+        if (string.IsNullOrWhiteSpace(settings.PluginsFolder) || !Directory.Exists(settings.PluginsFolder))
+        {
+            settings.PluginsFolder = resolveDefault(settings.PluginsFolder);
+        }
+        if (string.IsNullOrWhiteSpace(settings.ToolsFolder) || !Directory.Exists(settings.ToolsFolder))
+        {
+            settings.ToolsFolder = resolveDefault(settings.ToolsFolder);
+        }
     }
     public bool Save(out string? error)
     {

--- a/SharpMind.Tests/CUI/AppSettingsFolderDefaultsTests.cs
+++ b/SharpMind.Tests/CUI/AppSettingsFolderDefaultsTests.cs
@@ -1,0 +1,100 @@
+using SharpMind.CUI.App;
+
+namespace SharpMind.Tests.CUI;
+
+/// <summary>
+/// The folder-defaulting decision in <see cref="AppSettings.Load"/>, tested as a pure
+/// function: the resolver is injected so no test creates a directory or reads the real
+/// user settings file.
+/// </summary>
+public sealed class AppSettingsFolderDefaultsTests
+{
+    private const string Resolved = @"X:\resolved\Plugins";
+    private const string Missing = @"X:\definitely\not\here";
+
+    private static readonly string Existing = Path.GetTempPath();
+
+    /// <summary>Records what it was asked to resolve, so a test can assert it was not called.</summary>
+    private sealed class Resolver
+    {
+        public List<string?> Calls { get; } = [];
+        public string Resolve(string? initial) { Calls.Add(initial); return Resolved; }
+    }
+
+    [Fact]
+    public void BlankToolsFolder_IsGivenTheDefault()
+    {
+        // The bug this covers: the guard tested ToolsFolder for blankness but checked and
+        // assigned PluginsFolder, so ToolsFolder was never defaulted. A null ToolsFolder
+        // means SessionLauncher loads no tool DLLs and PermissionGate adds no tools root.
+        var r = new Resolver();
+        var settings = new AppSettings { PluginsFolder = Existing, ToolsFolder = null };
+
+        AppSettings.ApplyFolderDefaults(settings, r.Resolve);
+
+        Assert.Equal(Resolved, settings.ToolsFolder);
+    }
+
+    [Fact]
+    public void BlankToolsFolder_DoesNotDisturbAValidPluginsFolder()
+    {
+        var r = new Resolver();
+        var settings = new AppSettings { PluginsFolder = Existing, ToolsFolder = "   " };
+
+        AppSettings.ApplyFolderDefaults(settings, r.Resolve);
+
+        Assert.Equal(Existing, settings.PluginsFolder);
+        Assert.Single(r.Calls);      // resolved once, for ToolsFolder only
+    }
+
+    [Fact]
+    public void MissingToolsFolder_IsGivenTheDefault()
+    {
+        var r = new Resolver();
+        var settings = new AppSettings { PluginsFolder = Existing, ToolsFolder = Missing };
+
+        AppSettings.ApplyFolderDefaults(settings, r.Resolve);
+
+        Assert.Equal(Resolved, settings.ToolsFolder);
+    }
+
+    [Fact]
+    public void BlankPluginsFolder_IsGivenTheDefault()
+    {
+        var r = new Resolver();
+        var settings = new AppSettings { PluginsFolder = null, ToolsFolder = Existing };
+
+        AppSettings.ApplyFolderDefaults(settings, r.Resolve);
+
+        Assert.Equal(Resolved, settings.PluginsFolder);
+        Assert.Equal(Existing, settings.ToolsFolder);
+        Assert.Single(r.Calls);
+    }
+
+    [Fact]
+    public void BothFoldersValid_AreLeftAlone()
+    {
+        var r = new Resolver();
+        var settings = new AppSettings { PluginsFolder = Existing, ToolsFolder = Existing };
+
+        AppSettings.ApplyFolderDefaults(settings, r.Resolve);
+
+        Assert.Equal(Existing, settings.PluginsFolder);
+        Assert.Equal(Existing, settings.ToolsFolder);
+        Assert.Empty(r.Calls);
+    }
+
+    [Fact]
+    public void EachFolderIsResolvedFromItsOwnCurrentValue()
+    {
+        // The resolver falls back to the value it was handed when it cannot create the
+        // directory, so passing the wrong field's value would make that fallback restore
+        // the wrong path.
+        var r = new Resolver();
+        var settings = new AppSettings { PluginsFolder = Missing, ToolsFolder = Missing + "-tools" };
+
+        AppSettings.ApplyFolderDefaults(settings, r.Resolve);
+
+        Assert.Equal([Missing, Missing + "-tools"], r.Calls);
+    }
+}


### PR DESCRIPTION
Three copy-paste slips in one statement, in `AppSettings.Load` (from `82a686d`):

```csharp
if (string.IsNullOrWhiteSpace(settings.ToolsFolder) || !Directory.Exists(settings.PluginsFolder))
{
    settings.PluginsFolder = GetDefaultPluginPath(settings.PluginsFolder);
}
```

It tests `ToolsFolder` for blankness, then checks and assigns `PluginsFolder`. So `ToolsFolder` is never defaulted, and `PluginsFolder` gets resolved a second time.

The visible effect: on a fresh install with no settings file, `ToolsFolder` stays null, so `SessionLauncher.LoadToolAssemblies` has no path to scan (`SessionLauncher.cs:501`) and `PermissionGate` adds no tools root (`PermissionGate.cs:91`) — tools are unavailable even though `SharpMind.Extensions.Tools.dll` ships beside the app.

### The change

The fix is `ToolsFolder` in all three places. I also lifted the decision out of `Load` into `ApplyFolderDefaults(settings, resolveDefault)` with the resolver injected, because otherwise there is no way to test it that does not read the real user settings file and create directories on the test machine. `Load` still passes `GetDefaultPluginPath`, so behaviour is unchanged apart from the fix.

### Tests

Six, in `SharpMind.Tests/CUI/AppSettingsFolderDefaultsTests.cs`. **Five fail against the current code:**

```
BlankToolsFolder_IsGivenTheDefault                  Assert.Equal() Failure: Strings differ
MissingToolsFolder_IsGivenTheDefault                Assert.Equal() Failure: Strings differ
BlankToolsFolder_DoesNotDisturbAValidPluginsFolder  Assert.Equal() Failure: Strings differ
BlankPluginsFolder_IsGivenTheDefault                Assert.Single() Failure: The collection contained 2 items
EachFolderIsResolvedFromItsOwnCurrentValue          Assert.Equal() Failure: Collections differ
```

The sixth, `BothFoldersValid_AreLeftAlone`, passes before and after — it guards the other direction, so the fix cannot turn into over-eager re-resolution of folders the user has already set.

`EachFolderIsResolvedFromItsOwnCurrentValue` is worth a word: `GetDefaultPluginPath` falls back to the value it was handed when it cannot create the directory, so passing the wrong field's value there would make that fallback quietly restore the wrong path. The test pins each field to its own.

Full suite **1123/1123**.

### One thing that is your call

Both folders still default to the same `<base>/Plugins` directory, since that is where `SharpMind.Extensions.Tools.dll` actually ships. If you would rather tools defaulted to their own `<base>/Tools`, say so and I will follow up — I did not want to invent a second convention inside a bug fix.
