### PR TITLE
Fix OpenAI server answering a prompt the caller never sent

### DIFF
--- a/SharpMind.Server/Protocol/OpenAiMapper.cs
+++ b/SharpMind.Server/Protocol/OpenAiMapper.cs
@@ -43,6 +43,20 @@ public static class OpenAiMapper
     }
 
     /// <summary>
+    /// True when a stream entry carries model output that belongs in the completion.
+    /// </summary>
+    /// <remarks>
+    /// Progress entries reuse <see cref="ChatStreamEntry.Token"/> for status text
+    /// (<c>"Prefilling 50.25%"</c>) under <see cref="ChatStatus.Updating"/>, so a
+    /// consumer that concatenates every non-empty Token emits that to the client as
+    /// if the model had said it. The streaming and non-streaming paths each wrote
+    /// this rule out separately and drifted — streaming filtered, non-streaming did
+    /// not — so it lives in one place now.
+    /// </remarks>
+    public static bool IsContent(ChatStreamEntry entry)
+        => entry is { Status: ChatStatus.Responding or ChatStatus.Thinking, Token: { Length: > 0 } };
+
+    /// <summary>
     /// Map OpenAI request params to session properties.
     /// </summary>
     public static void ApplyToSession(CreateChatCompletionRequest request, IChatSession session)

--- a/SharpMind.Server/SessionFactory.cs
+++ b/SharpMind.Server/SessionFactory.cs
@@ -64,11 +64,18 @@ public sealed class SessionFactory(SharpMindServerOptions options)
         // Map OpenAI params → session properties
         OpenAiMapper.ApplyToSession(request, session);
 
-        // Set context window
-        int effectiveCacheLen = ModelConfig.ComputeMaxCacheLength(loaded.Model.Config, _options.MaxCacheLen);
-        session.MaxTokens = session.MaxNewTokens > 0
-            ? Math.Min(session.MaxNewTokens, effectiveCacheLen)
-            : effectiveCacheLen;
+        // Set context window.
+        //
+        // MaxTokens is the CONTEXT WINDOW; MaxNewTokens is the GENERATION limit.
+        // This used to clamp the window to `Math.Min(MaxNewTokens, cacheLen)`,
+        // which made ChatSession.TrimToFitContext compute
+        // `contextBudget = MaxTokens - MaxNewTokens = 0`, fall back to
+        // `MaxTokens / 2`, and cut the prompt down to a handful of tokens — so
+        // every completion answered a prompt the caller never sent (and
+        // `max_tokens: 1` trimmed to zero and threw "Prompt produced no token
+        // IDs"). The two values are not interchangeable: leaving room for the
+        // response is already TrimToFitContext's job.
+        session.MaxTokens = ModelConfig.ComputeMaxCacheLength(loaded.Model.Config, _options.MaxCacheLen);
 
         // Replay conversation history — all messages EXCEPT the last user
         // message. The last user message is returned separately so the caller

--- a/SharpMind.Server/SharpMindService.cs
+++ b/SharpMind.Server/SharpMindService.cs
@@ -355,11 +355,13 @@ public sealed class SharpMindService : IAsyncDisposable
         {
             await foreach (var entry in session.GetResponseStreamAsync(lastUserMessage, null, ct))
             {
-                if (entry.Token is { Length: > 0 } delta)
-                {
-                    sb.Append(delta);
-                    Interlocked.Increment(ref tokenCount);
-                }
+                // Status-only entries carry their status text in Token; appending
+                // every non-empty Token put "Prefilling 50.25%..." in the completion.
+                // The streaming path below filtered these out, this one did not.
+                if (!OpenAiMapper.IsContent(entry)) continue;
+
+                sb.Append(entry.Token);
+                Interlocked.Increment(ref tokenCount);
             }
         }
         catch (OperationCanceledException)
@@ -406,15 +408,11 @@ public sealed class SharpMindService : IAsyncDisposable
             {
                 // Skip prefill progress and other status-only entries — only
                 // stream actual token content to the client.
-                if (entry.Status != ChatStatus.Responding && entry.Status != ChatStatus.Thinking)
-                    continue;
+                if (!OpenAiMapper.IsContent(entry)) continue;
 
-                if (entry.Token is { Length: > 0 } delta)
-                {
-                    Interlocked.Increment(ref tokenCount);
-                    var chunk = OpenAiMapper.ToStreamChunk(completionId, created, loaded.ModelId, delta, null, null);
-                    await WriteSSE(writer, chunk, options);
-                }
+                Interlocked.Increment(ref tokenCount);
+                var chunk = OpenAiMapper.ToStreamChunk(completionId, created, loaded.ModelId, entry.Token, null, null);
+                await WriteSSE(writer, chunk, options);
             }
         }
         catch (OperationCanceledException) { }

--- a/SharpMind.Tests/Server/OpenAiMapperTests.cs
+++ b/SharpMind.Tests/Server/OpenAiMapperTests.cs
@@ -9,6 +9,47 @@ namespace SharpMind.Tests.Server;
 
 public class OpenAiMapperTests
 {
+    // ── IsContent ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Progress entries reuse Token for status text, so the non-streaming path
+    /// concatenated "Prefilling 3.99%Prefilling 7.98%..." into the completion.
+    /// Only visible on prompts long enough to prefill in more than one chunk —
+    /// which is why it hid behind the context-window bug.
+    /// </summary>
+    [Fact]
+    public void IsContent_RejectsPrefillProgressEntries()
+    {
+        var progress = new ChatStreamEntry { Status = ChatStatus.Updating, Token = "Prefilling 50.25%" };
+        Assert.False(OpenAiMapper.IsContent(progress));
+    }
+
+    [Theory]
+    [InlineData(ChatStatus.Responding)]
+    [InlineData(ChatStatus.Thinking)]
+    public void IsContent_AcceptsModelOutput(ChatStatus status)
+    {
+        Assert.True(OpenAiMapper.IsContent(new ChatStreamEntry { Status = status, Token = "hello" }));
+    }
+
+    [Theory]
+    [InlineData(ChatStatus.Updating)]
+    [InlineData(ChatStatus.Executing)]
+    [InlineData(ChatStatus.Waiting)]
+    [InlineData(ChatStatus.Researching)]
+    [InlineData(ChatStatus.ToolCall)]
+    public void IsContent_RejectsStatusOnlyEntries(ChatStatus status)
+    {
+        Assert.False(OpenAiMapper.IsContent(new ChatStreamEntry { Status = status, Token = "status text" }));
+    }
+
+    [Fact]
+    public void IsContent_RejectsEmptyAndNullTokens()
+    {
+        Assert.False(OpenAiMapper.IsContent(new ChatStreamEntry { Status = ChatStatus.Responding, Token = "" }));
+        Assert.False(OpenAiMapper.IsContent(new ChatStreamEntry { Status = ChatStatus.Responding, Token = null }));
+    }
+
     // ── ToChatHistory ────────────────────────────────────────────────────
 
     [Fact]

--- a/SharpMind.Tests/Server/SessionFactoryTests.cs
+++ b/SharpMind.Tests/Server/SessionFactoryTests.cs
@@ -1,0 +1,112 @@
+using SharpMind.Core;
+using SharpMind.Model;
+using SharpMind.Model.Config;
+using SharpMind.Model.Format;
+using SharpMind.Server;
+using SharpMind.Server.Protocol;
+using SharpMind.Tokenization;
+using SharpMind.Tokenization.Vocab;
+using SharpMind.Training;
+using Xunit;
+
+namespace SharpMind.Tests.Server;
+
+/// <summary>
+/// Guards the request -> session mapping. The server had no coverage here at all,
+/// which is how it shipped answering prompts the caller never sent.
+/// </summary>
+public class SessionFactoryTests
+{
+    private const int ModelMaxSeqLen = 1024;
+
+    private static LoadedModel MakeLoadedModel()
+    {
+        var cfg = new ModelConfig
+        {
+            VocabSize = 256, HiddenDim = 8, NumLayers = 1, NumHeads = 2,
+            NumKvHeads = 2, FfnDim = 16, MaxSeqLen = ModelMaxSeqLen,
+        };
+
+        var tokens = new List<string>();
+        for (int b = 0; b < 256; b++) tokens.Add(Vocabulary.ByteTokenString(b));
+        var tokenizer = Tokenizer.FromGguf([.. tokens], merges: null, tokenTypes: null, bosId: -1, eosId: -1);
+
+        var sharpConfig = SharpMindConfig.Gpt with { Hardware = HardwareTier.Scalar };
+        var weights = ModelFactory.CreateForTraining(cfg, sharpConfig);
+        WeightInitializer.InitializeRandomly(weights, 1234);
+        var model = ModelFactory.CreateTrainingTransformer(weights, sharpConfig);
+
+        return new LoadedModel
+        {
+            ModelId = "test-model",
+            FilePath = "test-model.gguf",
+            Model = model,
+            Tokenizer = tokenizer,
+            Meta = new ModelMetaData(),
+        };
+    }
+
+    private static CreateChatCompletionRequest Request(int? maxTokens, string userText) => new()
+    {
+        Model = "test-model",
+        MaxTokens = maxTokens,
+        Messages = [new UserMessage { Content = userText }],
+    };
+
+    /// <summary>
+    /// `max_tokens` is a GENERATION limit, not a context window. Feeding it into
+    /// <see cref="IChatSession.MaxTokens"/> made <c>TrimToFitContext</c> compute
+    /// <c>contextBudget = MaxTokens - MaxNewTokens = 0</c>, fall back to
+    /// <c>MaxTokens / 2</c>, and cut the prompt to a handful of tokens — so every
+    /// completion answered a prompt the caller never sent.
+    /// </summary>
+    [Theory]
+    [InlineData(1)]
+    [InlineData(16)]
+    [InlineData(256)]
+    public void CreateSession_KeepsFullContextWindow_RegardlessOfMaxTokens(int maxTokens)
+    {
+        using var loaded = MakeLoadedModel();
+        var factory = new SessionFactory(new SharpMindServerOptions());
+
+        var (session, _) = factory.CreateSession(loaded, Request(maxTokens, "hello"));
+
+        int expected = ModelConfig.ComputeMaxCacheLength(loaded.Model.Config, null);
+
+        Assert.Equal(maxTokens, session.MaxNewTokens);
+        Assert.Equal(expected, session.MaxTokens);
+    }
+
+    /// <summary>
+    /// The trim budget is <c>MaxTokens - MaxNewTokens</c>, so a prompt this long
+    /// must still fit. Before the fix the budget was 8 tokens and the message was
+    /// discarded entirely.
+    /// </summary>
+    [Fact]
+    public void CreateSession_LeavesRoomForTheActualPrompt()
+    {
+        using var loaded = MakeLoadedModel();
+        var factory = new SessionFactory(new SharpMindServerOptions());
+
+        // Byte tokenizer: one token per character.
+        string userText = new('x', 400);
+        var (session, lastUserMessage) = factory.CreateSession(loaded, Request(16, userText));
+
+        Assert.Equal(userText, lastUserMessage);
+        Assert.True(
+            session.MaxTokens - session.MaxNewTokens >= userText.Length,
+            $"context budget {session.MaxTokens - session.MaxNewTokens} cannot hold a {userText.Length}-token prompt");
+    }
+
+    /// <summary>Omitting max_tokens must not change the context window either.</summary>
+    [Fact]
+    public void CreateSession_WithoutMaxTokens_UsesCacheLength()
+    {
+        using var loaded = MakeLoadedModel();
+        var factory = new SessionFactory(new SharpMindServerOptions());
+
+        var (session, _) = factory.CreateSession(loaded, Request(null, "hello"));
+
+        Assert.Equal(ModelConfig.ComputeMaxCacheLength(loaded.Model.Config, null), session.MaxTokens);
+    }
+}


### PR DESCRIPTION
Every `/v1/chat/completions` response was independent of the request. Two defects, the second hidden behind the first.

## 1. `SessionFactory` used `max_tokens` as the context window

`session.MaxTokens` is the **context window**; `MaxNewTokens` is the **generation limit**. `CreateSession` clamped the window to `Math.Min(MaxNewTokens, cacheLen)`, so `ChatSession.TrimToFitContext` computed `contextBudget = MaxTokens - MaxNewTokens = 0`, fell back to `MaxTokens / 2`, and cut the prompt down to a handful of tokens.

- `max_tokens: 16` → the model saw **8 tokens** of prompt and answered from the chat template alone
- `max_tokens: 1` → budget 0 → `InvalidOperationException: Prompt produced no token IDs; cannot generate.` (HTTP 500)
- omitting `max_tokens` was no escape — `MaxNewTokens` defaults to 256, so every request ran with a 256-token window and a 128-token prompt budget

Leaving room for the response is already `TrimToFitContext`'s job; the two values are not interchangeable.

## 2. The non-streaming path concatenated status entries into the completion

Progress entries reuse `ChatStreamEntry.Token` for status text (`"Prefilling 50.25%"`) under `ChatStatus.Updating`. `HandleNonStreamingResponse` appended every non-empty `Token`, so any prompt long enough to prefill in more than one chunk came back as:

```
Prefilling 3.99%Prefilling 7.98%Prefilling 11.96%Prefilling 15.95%...
```

`HandleStreamingResponse` already filtered these out — the rule was written out twice and drifted. It now lives in `OpenAiMapper.IsContent` and both paths call it.

This one was invisible until defect 1 was fixed, because trimming kept every prompt inside a single prefill chunk.

## Evidence

Against a running server with `qwen2-0_5b-instruct-q8_0`:

| | before | after |
|---|---|---|
| `"What is 17 plus 25?"` | `"I'm sorry, but I need more information to provide a suitable response."` | `"The sum of 17 and 25 is 42."` |
| access code buried ~800 tokens into a 7.6 KB prompt | `"Prefilling 3.99%Prefilling 7.98%..."` | `"7741"` |
| `max_tokens: 1` | HTTP 500 | HTTP 200 |
| 2-token vs 2600-token prompt | 0.42s vs 0.47s (prompt was being discarded) | 0.49s vs 5.54s |

The identical canned reply for every prompt, and the flat timing across prompt sizes, are what make defect 1 easy to confirm on any build.

## Tests

The request-to-session mapping had **no coverage at all**, which is how this shipped. Adds:

- `SessionFactoryTests` — the context window must not track `max_tokens` (theory over 1/16/256, plus the no-`max_tokens` case), and the trim budget must still hold a 400-token prompt
- `OpenAiMapperTests` — `IsContent` accepts `Responding`/`Thinking` with a non-empty token and rejects `Updating` and the other status-only kinds

Suite: **1131/1131**.

## Not fixed here: `SharpMind.Live` has the same status-entry leak

`SharpMind.Live/Services/SharpMindWasmService.cs` consumes the same stream and appends every non-null `Token`:

```csharp
await foreach (var entry in _state.Session.GetResponseStreamAsync(prompt))
{
    if (entry.Status == ChatStatus.Complete ||
        entry.Status == ChatStatus.Interrupted)
        break;

    if (entry.Token is not null)      // <-- status entries land here too
    {
        sb.Append(entry.Token);
        tokens++;
        StreamTokens(entry.Token);
    }
}
```

So the WASM demo concatenates `"Prefilling NN.NN%"` into its replies for any prompt that prefills in more than one chunk — the same defect as 2 above, on the surface most people see first. The same guard fixes it:

```csharp
if (entry.Status is not (ChatStatus.Responding or ChatStatus.Thinking))
    continue;
```

I have deliberately left it out of this PR: `SharpMind.Live` needs the `wasm-tools` workload, which I don't have installed, so I could not build or run it and will not ship a change I haven't compiled. Happy to add it here, or send it separately, if you'd like it to travel with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159PK7ySzq6KpTvSUkvbYiY
