### PR TITLE
Make the server's startup preload actually run

### DIFF
--- a/SharpMind.Server.CLI/Program.cs
+++ b/SharpMind.Server.CLI/Program.cs
@@ -87,8 +87,12 @@ static async Task RunServiceAsync(SharpMindServerOptions options, List<string> m
         {
             Console.WriteLine($"[SharpMind] Pre-loading model: {modelArg}");
             var progress = new Progress<string>(msg => Console.WriteLine($"[SharpMind] {msg}"));
-            await server.PreloadModelAsync(modelArg, progress, cts.Token);
-            Console.WriteLine($"[SharpMind] Model loaded: {modelArg}");
+            // Report what actually happened. This used to print "Model loaded"
+            // unconditionally, so an unknown model id read as a success.
+            if (await server.PreloadModelAsync(modelArg, progress, cts.Token))
+                Console.WriteLine($"[SharpMind] Model loaded: {modelArg}");
+            else
+                Console.Error.WriteLine($"[SharpMind] Model '{modelArg}' not found in {options.ResolvedModelsDir} — not preloaded. Use an id from /v1/models (they include the file extension).");
         }
         catch (Exception ex)
         {

--- a/SharpMind.Server/SharpMindService.cs
+++ b/SharpMind.Server/SharpMindService.cs
@@ -56,6 +56,12 @@ public sealed class SharpMindService : IAsyncDisposable
     /// </summary>
     public IHost BuildHost()
     {
+        // Cache it. This used to build and return without assigning _host, so
+        // PreloadModelAsync — which reads _host — threw "Host not built" even
+        // when the caller had just called BuildHost(), and StartAsync then built
+        // a second host through its own `_host ??=`.
+        if (_host is not null) return _host;
+
         var builder = WebApplication.CreateBuilder();
 
         builder.Services.AddSharpMindServer(opts =>
@@ -70,19 +76,21 @@ public sealed class SharpMindService : IAsyncDisposable
         var app = builder.Build();
         app.Urls.Add($"http://{Options.Host}:{Options.Port}");
         MapEndpoints(app);
+        _host = app;
         return app;
     }
 
     /// <summary>
-    /// Load a single model by name. Useful before the host is built (e.g. to
-    /// pre-warm a model at startup). Requires that <see cref="BuildHost"/>
-    /// was called first.
+    /// Load a single model by name at startup, e.g. to pre-warm it before the
+    /// server begins listening. Calls <see cref="BuildHost"/> if it has not run
+    /// yet. Returns false when <paramref name="modelId"/> is not in the models
+    /// directory, so a caller can report an unknown id instead of assuming success.
     /// </summary>
-    public async Task PreloadModelAsync(string modelId, IProgress<string>? progress = null, CancellationToken ct = default)
+    public async Task<bool> PreloadModelAsync(string modelId, IProgress<string>? progress = null, CancellationToken ct = default)
     {
-        var app = (WebApplication)(_host ?? throw new InvalidOperationException("Host not built."));
+        var app = (WebApplication)(_host ??= BuildHost());
         var modelManager = app.Services.GetRequiredService<ModelManager>();
-        await modelManager.LoadAsync(modelId, progress ?? CreateProgress(), ct);
+        return await modelManager.PreloadAsync(modelId, progress ?? CreateProgress(), ct);
     }
 
     /// <summary>

--- a/SharpMind.Tests/Server/ServiceStartupPreloadTests.cs
+++ b/SharpMind.Tests/Server/ServiceStartupPreloadTests.cs
@@ -1,0 +1,96 @@
+using SharpMind.Server;
+
+namespace SharpMind.Tests.Server;
+
+/// <summary>
+/// Regression cover for the startup preload path
+/// (<see cref="SharpMindService.PreloadModelAsync"/>).
+///
+/// <c>BuildHost</c> built the host and returned it without assigning
+/// <c>_host</c>. <c>PreloadModelAsync</c> reads <c>_host</c>, so it threw
+/// "Host not built." even though the CLI calls <c>BuildHost()</c> on the line
+/// before — and <c>StartAsync</c>, whose <c>_host ??= BuildHost()</c> had no
+/// cached value to find, then built a second host. The result was that
+/// <c>--model</c> at startup never preloaded anything and reported a failure
+/// while the server came up regardless.
+///
+/// These tests use an empty models directory: an unknown model id exercises
+/// the whole path down to the directory scan without loading any weights.
+/// </summary>
+public sealed class ServiceStartupPreloadTests
+{
+    private static SharpMindServerOptions EmptyModelsDir(string dir) =>
+        new() { ModelsDir = dir, Port = 0 };
+
+    private static string NewTempDir()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "sharpmind_test_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void BuildHost_IsIdempotent()
+    {
+        string dir = NewTempDir();
+        try
+        {
+            var service = new SharpMindService(EmptyModelsDir(dir));
+
+            var first = service.BuildHost();
+            var second = service.BuildHost();
+
+            // Not merely equal — the same host, or the service is holding a
+            // different one than the caller was handed.
+            Assert.Same(first, second);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task PreloadModelAsync_AfterBuildHost_DoesNotThrowHostNotBuilt()
+    {
+        string dir = NewTempDir();
+        try
+        {
+            var service = new SharpMindService(EmptyModelsDir(dir));
+            _ = service.BuildHost();   // exactly what the CLI does before preloading
+
+            bool loaded = await service.PreloadModelAsync("absent.gguf");
+
+            Assert.False(loaded);      // unknown id — but reached the scan, not an exception
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task PreloadModelAsync_WithoutBuildHost_BuildsItsOwnHost()
+    {
+        string dir = NewTempDir();
+        try
+        {
+            var service = new SharpMindService(EmptyModelsDir(dir));
+
+            bool loaded = await service.PreloadModelAsync("absent.gguf");
+
+            Assert.False(loaded);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task PreloadModelAsync_UnknownModel_ReturnsFalse()
+    {
+        string dir = NewTempDir();
+        try
+        {
+            // A real model file is present, so "not found" is about the id and
+            // not about an empty directory.
+            File.WriteAllBytes(Path.Combine(dir, "present.gguf"), [1, 2, 3]);
+            var service = new SharpMindService(EmptyModelsDir(dir));
+
+            Assert.False(await service.PreloadModelAsync("absent.gguf"));
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}


### PR DESCRIPTION
`SharpMind.Server.CLI --model <id>` has never preloaded a model. It prints a load failure and the server comes up with a cold, empty model cache.

### Why

`SharpMindService.BuildHost()` built the host and returned it **without assigning `_host`**.

`Program.cs` does `_ = server.BuildHost();` and then calls `PreloadModelAsync`, which reads `_host` — so it hit `_host ?? throw new InvalidOperationException("Host not built.")` on the line right after `BuildHost()` succeeded. The exception was caught and printed as a preload failure. `StartAsync`'s `_host ??= BuildHost()` then found nothing cached and built a **second** host.

`ModelManager.PreloadAsync` is declared but called from nowhere; the preload path went through `LoadAsync` instead and returned `void`, so the CLI printed `Model loaded: <id>` unconditionally — an unknown model id read as a success.

### What changed

- `BuildHost` caches and returns the host it built (`if (_host is not null) return _host;` + `_host = app;`). It is now idempotent, and the duplicate host is gone.
- `PreloadModelAsync` builds one itself if the caller has not (`_host ??= BuildHost()`), so it no longer depends on call order.
- It routes through `ModelManager.PreloadAsync` and returns its `bool` instead of `void`.
- The CLI reports the actual result. An unknown id now names the models directory and points at `/v1/models` for the correct id form (they include the file extension).

3 files, +116/-8. No behaviour change for anything that was already working - `StartAsync` and `RunAsync` are untouched.

### What the tests pin

The fixture uses an empty models directory, so an unknown id exercises the whole path down to the directory scan without loading weights - the tests need no model file and take milliseconds.

| test | branch covered |
| --- | --- |
| `BuildHost_IsIdempotent` | two calls return the *same* host instance, not merely equal ones |
| `PreloadModelAsync_AfterBuildHost_DoesNotThrowHostNotBuilt` | exactly the CLI's call order - the defective path |
| `PreloadModelAsync_WithoutBuildHost_BuildsItsOwnHost` | preload with no prior `BuildHost` |
| `PreloadModelAsync_UnknownModel_ReturnsFalse` | a real model file is present, so "not found" is about the id, not an empty directory |

### Verification

- 4/4 pass on current `master` (`608bbef`).
- Mutation check - reverting the `_host` caching and restoring `_host ?? throw`: all four fail, three with the production `Host not built.` and one on the duplicate host. Restoring the fix returns them to green.
- Full suite green: 1207 passed / 0 failed.
- `SharpMind.Server.CLI` builds clean in Release, 0 warnings.
