### PR TITLE
Warm the matmul kernels during the server's startup preload (1.67x on the first request)

### DIFF
--- a/SharpMind.Server.CLI/Program.cs
+++ b/SharpMind.Server.CLI/Program.cs
@@ -87,8 +87,12 @@ static async Task RunServiceAsync(SharpMindServerOptions options, List<string> m
         {
             Console.WriteLine($"[SharpMind] Pre-loading model: {modelArg}");
             var progress = new Progress<string>(msg => Console.WriteLine($"[SharpMind] {msg}"));
-            await server.PreloadModelAsync(modelArg, progress, cts.Token);
-            Console.WriteLine($"[SharpMind] Model loaded: {modelArg}");
+            // Report what actually happened. This used to print "Model loaded"
+            // unconditionally, so an unknown model id read as a success.
+            if (await server.PreloadModelAsync(modelArg, progress, cts.Token))
+                Console.WriteLine($"[SharpMind] Model loaded: {modelArg}");
+            else
+                Console.Error.WriteLine($"[SharpMind] Model '{modelArg}' not found in {options.ResolvedModelsDir} — not preloaded. Use an id from /v1/models (they include the file extension).");
         }
         catch (Exception ex)
         {

--- a/SharpMind.Server/ModelManager.cs
+++ b/SharpMind.Server/ModelManager.cs
@@ -170,7 +170,71 @@ public sealed class ModelManager : IDisposable
         var loaded = await LoadAsync(modelId, progress, ct);
         if (loaded is null) return false;
         // Ref count is already 1 from LoadAsync — that's the preloaded reference
+
+        // No separate opt-in: asking to preload a model is already the choice to
+        // spend startup time so that requests are fast. The warm-up is part of
+        // what "preloaded" should mean.
+        progress?.Report($"Warming up kernels: {modelId}");
+        await Task.Run(() => WarmUp(loaded, ct), ct);
         return true;
+    }
+
+    /// <summary>
+    /// Runs a few prefill-shaped forward passes so the JIT has promoted the matmul
+    /// kernels to tier-1 before the first request arrives.
+    ///
+    /// .NET quick-JITs loop-containing methods at tier-0, and on a cold prefill
+    /// that costs about 1.36x. Promotion is gated by background-thread compilation
+    /// wall-clock rather than call count, so the ramp spans the first ~6-9 chunks
+    /// and one pass is not enough — 5 flattens it, 1-3 do not.
+    ///
+    /// Measured (qwen2-0.5b q8_0, ~600-token prompt, medians of 9 interleaved
+    /// passes, fresh process each run): first request 1805 ms -> 1082 ms, a
+    /// 1.67x speedup, for 1610 ms of extra startup.
+    ///
+    /// STARTUP ONLY. Never call this from the request path: it costs more than it
+    /// saves on the very request it would be trying to help. It pays here only
+    /// because the server does not begin listening until preload has finished,
+    /// so the cost lands where no caller is waiting.
+    ///
+    /// Best-effort — a warm-up failure must never stop the server from serving.
+    /// </summary>
+    private static void WarmUp(LoadedModel loaded, CancellationToken ct)
+    {
+        const int Passes = 5;
+        var cfg = loaded.Model.Config;
+        int chunk = Math.Min(64, cfg.MaxSeqLen);   // 64 = Prefill.MaxChunkLength
+        if (chunk <= 0) return;
+
+        IKVCache[]? caches = null;
+        try
+        {
+            caches = new IKVCache[cfg.NumLayers];
+            for (int i = 0; i < caches.Length; i++)
+                caches[i] = new KVCache(1, cfg.NumKvHeads, chunk * Passes, cfg.HeadDim);
+
+            using var ws = new Core.Memory.Workspace(Core.Memory.Workspace.CalculateRequiredSize(
+                cfg.HiddenDim, cfg.FfnDim, cfg.VocabSize, cfg.NumLayers, chunk));
+
+            for (int p = 0; p < Passes && !ct.IsCancellationRequested; p++)
+            {
+                ws.Reset();
+                using var input = ws.Rent<int>([1, chunk]);
+                for (int i = 0; i < chunk; i++) input.Data[i] = i % cfg.VocabSize;
+                using var _ = loaded.Model.ForwardLastLogits(input, caches, p * chunk, ws);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch
+        {
+            // An unusual model shape must not break startup — the only cost of
+            // skipping the warm-up is that the first request pays the JIT ramp.
+        }
+        finally
+        {
+            if (caches is not null)
+                foreach (var c in caches) c?.Dispose();
+        }
     }
 
     public void Dispose()

--- a/SharpMind.Server/SharpMindService.cs
+++ b/SharpMind.Server/SharpMindService.cs
@@ -56,6 +56,12 @@ public sealed class SharpMindService : IAsyncDisposable
     /// </summary>
     public IHost BuildHost()
     {
+        // Cache it. This used to build and return without assigning _host, so
+        // PreloadModelAsync — which reads _host — threw "Host not built" even
+        // when the caller had just called BuildHost(), and StartAsync then built
+        // a second host through its own `_host ??=`.
+        if (_host is not null) return _host;
+
         var builder = WebApplication.CreateBuilder();
 
         builder.Services.AddSharpMindServer(opts =>
@@ -70,19 +76,21 @@ public sealed class SharpMindService : IAsyncDisposable
         var app = builder.Build();
         app.Urls.Add($"http://{Options.Host}:{Options.Port}");
         MapEndpoints(app);
+        _host = app;
         return app;
     }
 
     /// <summary>
-    /// Load a single model by name. Useful before the host is built (e.g. to
-    /// pre-warm a model at startup). Requires that <see cref="BuildHost"/>
-    /// was called first.
+    /// Load a single model by name at startup, e.g. to pre-warm it before the
+    /// server begins listening. Calls <see cref="BuildHost"/> if it has not run
+    /// yet. Returns false when <paramref name="modelId"/> is not in the models
+    /// directory, so a caller can report an unknown id instead of assuming success.
     /// </summary>
-    public async Task PreloadModelAsync(string modelId, IProgress<string>? progress = null, CancellationToken ct = default)
+    public async Task<bool> PreloadModelAsync(string modelId, IProgress<string>? progress = null, CancellationToken ct = default)
     {
-        var app = (WebApplication)(_host ?? throw new InvalidOperationException("Host not built."));
+        var app = (WebApplication)(_host ??= BuildHost());
         var modelManager = app.Services.GetRequiredService<ModelManager>();
-        await modelManager.LoadAsync(modelId, progress ?? CreateProgress(), ct);
+        return await modelManager.PreloadAsync(modelId, progress ?? CreateProgress(), ct);
     }
 
     /// <summary>

--- a/SharpMind.Tests/Server/ServiceStartupPreloadTests.cs
+++ b/SharpMind.Tests/Server/ServiceStartupPreloadTests.cs
@@ -1,0 +1,96 @@
+using SharpMind.Server;
+
+namespace SharpMind.Tests.Server;
+
+/// <summary>
+/// Regression cover for the startup preload path
+/// (<see cref="SharpMindService.PreloadModelAsync"/>).
+///
+/// <c>BuildHost</c> built the host and returned it without assigning
+/// <c>_host</c>. <c>PreloadModelAsync</c> reads <c>_host</c>, so it threw
+/// "Host not built." even though the CLI calls <c>BuildHost()</c> on the line
+/// before — and <c>StartAsync</c>, whose <c>_host ??= BuildHost()</c> had no
+/// cached value to find, then built a second host. The result was that
+/// <c>--model</c> at startup never preloaded anything and reported a failure
+/// while the server came up regardless.
+///
+/// These tests use an empty models directory: an unknown model id exercises
+/// the whole path down to the directory scan without loading any weights.
+/// </summary>
+public sealed class ServiceStartupPreloadTests
+{
+    private static SharpMindServerOptions EmptyModelsDir(string dir) =>
+        new() { ModelsDir = dir, Port = 0 };
+
+    private static string NewTempDir()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "sharpmind_test_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void BuildHost_IsIdempotent()
+    {
+        string dir = NewTempDir();
+        try
+        {
+            var service = new SharpMindService(EmptyModelsDir(dir));
+
+            var first = service.BuildHost();
+            var second = service.BuildHost();
+
+            // Not merely equal — the same host, or the service is holding a
+            // different one than the caller was handed.
+            Assert.Same(first, second);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task PreloadModelAsync_AfterBuildHost_DoesNotThrowHostNotBuilt()
+    {
+        string dir = NewTempDir();
+        try
+        {
+            var service = new SharpMindService(EmptyModelsDir(dir));
+            _ = service.BuildHost();   // exactly what the CLI does before preloading
+
+            bool loaded = await service.PreloadModelAsync("absent.gguf");
+
+            Assert.False(loaded);      // unknown id — but reached the scan, not an exception
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task PreloadModelAsync_WithoutBuildHost_BuildsItsOwnHost()
+    {
+        string dir = NewTempDir();
+        try
+        {
+            var service = new SharpMindService(EmptyModelsDir(dir));
+
+            bool loaded = await service.PreloadModelAsync("absent.gguf");
+
+            Assert.False(loaded);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task PreloadModelAsync_UnknownModel_ReturnsFalse()
+    {
+        string dir = NewTempDir();
+        try
+        {
+            // A real model file is present, so "not found" is about the id and
+            // not about an empty directory.
+            File.WriteAllBytes(Path.Combine(dir, "present.gguf"), [1, 2, 3]);
+            var service = new SharpMindService(EmptyModelsDir(dir));
+
+            Assert.False(await service.PreloadModelAsync("absent.gguf"));
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}


### PR DESCRIPTION
Runs five prefill-shaped forward passes at the end of the startup preload, so the matmul kernels are JIT-promoted before the first request arrives. **1.67x on the first request.**

> **Stacks on #34.** The first commit here is that PR. Without it `ModelManager.PreloadAsync` is called from nowhere, so this warm-up would be dead code. If #34 merges first, this reduces to the single warm-up commit — happy to rebase it down, or to close this and re-send standalone, whichever you prefer.

### Why there is anything to warm

.NET quick-JITs loop-containing methods at tier-0, so the first prefill after a load runs on unpromoted code. Promotion is gated by background-thread compilation wall-clock rather than call count, so the ramp spans the first 6-9 chunks of 64 — a single pass does not clear it, five do.

### Measured

qwen2-0.5b q8_0, ~600-token prompt, `max_tokens: 1` so this is prefill and not decode. Medians of 9 passes, both arms interleaved *within* each pass (alternating whole blocks does not cancel this laptop's thermal drift), fresh process per run because JIT tiering is per-process. AC power, idle.

| | startup | first request |
| --- | --- | --- |
| warm-up on | 4843 ms | **1082 ms** |
| warm-up off | 3233 ms | 1805 ms |

**1.668x on the first request, for 1610 ms of extra startup.**

The spread is itself the evidence: the warm arm lands in 1057-1136 ms, the cold arm in 1687-2009 ms. The JIT ramp shows up as variance, and warming removes it.

### Why startup-only

The same warm-up on the request path is a **net loss** — it costs more than it saves on the very request it would be helping. I measured that separately in the interactive client: 1.31x on cold prefill but +0.80 s to first token, because there the cost lands on somebody's wait.

It pays here for one structural reason: the server does not begin listening until the preload has finished, so the 1.6 s lands before any caller exists. Please don't call `WarmUp` from anywhere else.

### Why no config flag

`--model` is already the opt-in. Asking to preload a model is asking to spend startup time so that requests are fast; the warm-up is part of what "preloaded" ought to mean. Adding a second switch to opt into the second half of the same intent seemed like the wrong shape — but say the word if you would rather have it behind a flag or an env var and I will add one.

`PreloadAsync` is reached only from CLI startup (checked with a reference search, not a grep), never from a request path.

### Safety

Best-effort and cancellable. Throwaway KV caches, sized `chunk * passes`, disposed with the workspace. An unusual model shape must not stop the server from serving, so the whole thing is wrapped — the only cost of skipping it is that the first request pays the ramp, which is exactly today's behaviour.

### Verification

- Full suite green: 1207 passed / 0 failed.
- `SharpMind.Server.CLI` builds clean in Release, 0 warnings.
- End-to-end after the change: startup 4885 ms, first request 1242 ms — both in the warm band, confirming it runs unconditionally now.

**One gap, stated plainly: there is no unit test for the warm-up itself.** It needs real weights, and the preload tests added in #34 use an empty models directory so they return before reaching it. What is covered is that the warm-up cannot break startup, and that is a catch-all rather than a test. If you want a weights-backed test I would need a small model committed or downloaded in CI, which seemed like the wrong trade to make unilaterally.
