### PR TITLE
Register the server's own options so --max-cache-len is not dropped

### DIFF
--- a/SharpMind.Server/SharpMindServerBuilder.cs
+++ b/SharpMind.Server/SharpMindServerBuilder.cs
@@ -64,6 +64,16 @@ public static class SharpMindServerExtensions
     {
         var options = new SharpMindServerOptions();
         configure?.Invoke(options);
+        return services.AddSharpMindServer(options);
+    }
+
+    /// <summary>
+    /// Register SharpMind server services with an existing options instance.
+    /// </summary>
+    public static IServiceCollection AddSharpMindServer(
+        this IServiceCollection services,
+        SharpMindServerOptions options)
+    {
         services.AddSingleton(options);
         services.AddSingleton<ModelManager>();
         services.AddSingleton<SessionFactory>();

--- a/SharpMind.Server/SharpMindService.cs
+++ b/SharpMind.Server/SharpMindService.cs
@@ -64,14 +64,9 @@ public sealed class SharpMindService : IAsyncDisposable
 
         var builder = WebApplication.CreateBuilder();
 
-        builder.Services.AddSharpMindServer(opts =>
-        {
-            opts.ModelsDir = Options.ModelsDir;
-            opts.Host = Options.Host;
-            opts.Port = Options.Port;
-            opts.DisableFileIO = Options.DisableFileIO;
-            opts.DisableNetworkIO = Options.DisableNetworkIO;
-        });
+        // Register this instance rather than copying fields into a new one: the
+        // copy skipped MaxCacheLen, so --max-cache-len was accepted and ignored.
+        builder.Services.AddSharpMindServer(Options);
 
         var app = builder.Build();
         app.Urls.Add($"http://{Options.Host}:{Options.Port}");

--- a/SharpMind.Tests/Server/ServiceStartupPreloadTests.cs
+++ b/SharpMind.Tests/Server/ServiceStartupPreloadTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using SharpMind.Server;
 
 namespace SharpMind.Tests.Server;
@@ -43,6 +44,31 @@ public sealed class ServiceStartupPreloadTests
             // Not merely equal — the same host, or the service is holding a
             // different one than the caller was handed.
             Assert.Same(first, second);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    /// <summary>
+    /// <c>BuildHost</c> copied options field by field into the DI-registered
+    /// instance and skipped <c>MaxCacheLen</c>, so <c>--max-cache-len</c> was
+    /// accepted by the CLI and then silently ignored by every session.
+    /// </summary>
+    [Fact]
+    public void BuildHost_RegistersEveryOption()
+    {
+        string dir = NewTempDir();
+        try
+        {
+            var options = EmptyModelsDir(dir);
+            options.MaxCacheLen = 128;
+            options.DisableFileIO = true;
+            var service = new SharpMindService(options);
+
+            var registered = service.BuildHost().Services.GetRequiredService<SharpMindServerOptions>();
+
+            Assert.Equal(128, registered.MaxCacheLen);
+            Assert.True(registered.DisableFileIO);
+            Assert.Equal(dir, registered.ModelsDir);
         }
         finally { Directory.Delete(dir, true); }
     }


### PR DESCRIPTION
`SharpMindService.BuildHost` copied five option fields into a fresh `SharpMindServerOptions` for DI and skipped `MaxCacheLen`. `SessionFactory` reads the DI instance, so `--max-cache-len` was parsed by the CLI and then ignored by every session, which sized its KV cache automatically instead.

**Fix at the boundary rather than the field:** `AddSharpMindServer` gains an overload that takes an options instance, and `BuildHost` registers the service's own `Options`. Nothing is copied field by field any more, so a future option cannot be dropped here either. The existing configure-delegate overload is unchanged and now delegates to the new one.

**Test:** `BuildHost_RegistersEveryOption` sets `MaxCacheLen`, `DisableFileIO` and `ModelsDir` and reads them back from the built host's services. Red before (registered `MaxCacheLen` was null), green after. Full suite green.
