### PR TITLE
Stream completions in the Server CLI instead of buffering the whole body

### DIFF
--- a/SharpMind.Server.CLI/Program.cs
+++ b/SharpMind.Server.CLI/Program.cs
@@ -634,21 +634,30 @@ static async Task<StringBuilder> StreamChatCompletion(HttpClient http, Dictionar
     });
 
     using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
-    var content = new StringContent(json, Encoding.UTF8, "application/json");
-    var response = await http.PostAsync("/v1/chat/completions", content, cts.Token);
+    // ResponseHeadersRead: PostAsync's default (ResponseContentRead) buffers the
+    // whole SSE body before returning, so nothing was displayed until generation
+    // had finished and the read loop below only ever replayed a complete answer.
+    using var httpRequest = new HttpRequestMessage(HttpMethod.Post, "/v1/chat/completions")
+    {
+        Content = new StringContent(json, Encoding.UTF8, "application/json"),
+    };
+    using var response = await http.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, cts.Token);
     response.EnsureSuccessStatusCode();
 
-    var stream = await response.Content.ReadAsStreamAsync(cts.Token);
-    var reader = new StreamReader(stream);
+    using var stream = await response.Content.ReadAsStreamAsync(cts.Token);
+    using var reader = new StreamReader(stream);
     var sb = new StringBuilder();
 
-    using var lineCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+    // Inactivity timeout: re-armed before every line, so a long answer that keeps
+    // producing tokens is not cut off at a fixed 30 s after the request started.
+    using var lineCts = new CancellationTokenSource();
 
     while (true)
     {
         string? line;
         try
         {
+            lineCts.CancelAfter(TimeSpan.FromSeconds(30));
             line = await reader.ReadLineAsync(lineCts.Token);
         }
         catch (OperationCanceledException)


### PR DESCRIPTION
`StreamChatCompletion` in the Server CLI awaited `HttpClient.PostAsync`, whose default completion option (`ResponseContentRead`) buffers the entire SSE body before returning. The read loop then replayed a finished answer, so a long response looked frozen until generation ended, and the 30-second line timeout only started counting after the body had already arrived.

**Fix:** send with `HttpCompletionOption.ResponseHeadersRead`, dispose the request, response, stream and reader, and re-arm the 30-second timeout before every line so it is an inactivity timeout instead of a single deadline from the start of the response.

**Verified** against a running service with a 300-word prompt, sampling the client's redirected stdout every 250 ms: before, it grew in a single step at exit; after, it grew on every sample from the first token on (13 steps over 6.3 s). No unit test — the CLI is top-level statements with no test project reference, and the HttpClient behaviour is documented.

While there: `RunClientAsync` has a stray `{ Console.WriteLine("[SharpMind] No models found. …") }` block after the model-resolution if/else chain (around line 178), so the client always prints "No models found" even when a model is loaded. Not touched in this PR since it is unrelated; happy to send it separately.
